### PR TITLE
Adjustments to Moth, Slime and Rat People Species Names

### DIFF
--- a/Resources/Locale/en-US/deltav/chat/managers/chat_manager.ftl
+++ b/Resources/Locale/en-US/deltav/chat/managers/chat_manager.ftl
@@ -16,7 +16,7 @@ chat-speech-verb-harpy-2 = tweets
 chat-speech-verb-harpy-3 = caws
 chat-speech-verb-harpy-4 = trills
 
-chat-speech-verb-name-rodentia = Rodentia
+chat-speech-verb-name-rodentia = Rodentian
 chat-speech-verb-rodentia-1 = squeaks
 chat-speech-verb-rodentia-2 = pieps
 chat-speech-verb-rodentia-3 = chatters

--- a/Resources/Locale/en-US/deltav/species/species.ftl
+++ b/Resources/Locale/en-US/deltav/species/species.ftl
@@ -2,4 +2,4 @@
 
 species-name-vulpkanin = Vulpkanin
 species-name-harpy = Harpy
-species-name-rodentia = Rodentia
+species-name-rodentia = Rodentian

--- a/Resources/Locale/en-US/species/species.ftl
+++ b/Resources/Locale/en-US/species/species.ftl
@@ -3,10 +3,10 @@
 species-name-human = Human
 species-name-dwarf = Dwarf
 species-name-reptilian = Reptilian
-species-name-slime = Slime Person
+species-name-slime = Amorphian
 species-name-diona = Diona
 species-name-arachnid = Arachnid
-species-name-moth = Moth Person
+species-name-moth = Lepidopteran
 species-name-skeleton = Skeleton
 species-name-vox = Vox
 

--- a/Resources/ServerInfo/Guidebook/Mobs/DeltaV/Rodentia.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/DeltaV/Rodentia.xml
@@ -1,11 +1,11 @@
 <Document>
-  # Rodentia
+  # Rodentians
 
   <Box>
     <GuideEntityEmbed Entity="MobRodentiaDummy" Caption=""/>
   </Box>
 
-  Rodentia are a race of humanoid beings resembling rodents. Resourceful, evasive, sneaky, but fragile.
+  Rodentians are a race of humanoid beings resembling rodents. Resourceful, evasive, sneaky, but fragile.
 
   ## Diet
 

--- a/Resources/ServerInfo/Guidebook/Mobs/Moth.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Moth.xml
@@ -1,5 +1,5 @@
 <Document>
-  # Moth People
+  # Lepidopterans
 
   <Box>
     <GuideEntityEmbed Entity="MobMoth" Caption=""/>

--- a/Resources/ServerInfo/Guidebook/Mobs/SlimePerson.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/SlimePerson.xml
@@ -1,5 +1,5 @@
 <Document>
-  # Slime People
+  # Amorphians
 
   <Box>
     <GuideEntityEmbed Entity="MobSlimePerson" Caption=""/>

--- a/Resources/ServerInfo/Guidebook/Mobs/Species.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Species.xml
@@ -13,15 +13,15 @@
   <Box>
   <GuideEntityEmbed Entity="MobHarpy" Caption="Harpy"/>
   <GuideEntityEmbed Entity="MobHuman" Caption="Human"/>
-  <GuideEntityEmbed Entity="MobMoth" Caption="Moth Person"/>
+  <GuideEntityEmbed Entity="MobMoth" Caption="Lepidopteran"/>
   <GuideEntityEmbed Entity="MobReptilian" Caption="Reptilian"/>
-  <GuideEntityEmbed Entity="MobSlimePerson" Caption="Slime Person"/>
+  <GuideEntityEmbed Entity="MobSlimePerson" Caption="Amorphian"/>
   <GuideEntityEmbed Entity="MobVox" Caption="Vox"/>
   </Box>
   <Box>
   <GuideEntityEmbed Entity="MobVox" Caption="Vox"/>
   <GuideEntityEmbed Entity="MobVulpkanin" Caption="Vuplkanin"/>
-  <GuideEntityEmbed Entity="MobRodentia" Caption="Rodentia"/>
+  <GuideEntityEmbed Entity="MobRodentia" Caption="Rodentian"/>
   </Box>
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC13CharacterNames.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC13CharacterNames.xml
@@ -1,9 +1,9 @@
 <Document>
-  # Core Rule 13 - Use realistic character names, and do not use names of famous people 
+  # Core Rule 13 - Use realistic character names, and do not use names of famous people
   - No names of people or characters fictional or real from our world. You are not slick if you switch a few letters around.
   - No titles/honorifics (Exceptions being generational titles like "Jr" or "I", "II", "III", etc), nicknames, or shortenings. Use proper capitalization (e.g. NOT J Hoffman or jaiden mallow).
   - Must follow all other rules (no slurs/sexual names/etc)
-  - Usernames, objects, random characters, very "low effort" names, "meta" names, or otherwise implausible names cannot be used as names. See examples below. 
+  - Usernames, objects, random characters, very "low effort" names, "meta" names, or otherwise implausible names cannot be used as names. See examples below.
   - Admin rulings on IC names are final and disputes should be done through the forums, not by refusing to comply with an admin
   - Species have naming conventions that are part of their in-universe culture. These may be subverted if they have sufficient in-character reasoning and effort to explain their non-standard name. Non-standard names are held to higher scrutiny and you may be questioned on why your name breaks these conventions.
 
@@ -17,8 +17,8 @@
 
   Any name considered [color=#449944]Good:[/color] can be used for the species it falls under. Any names considered [color=#994444]Bad:[/color] cannot be used for that specie or any other species.
 
-  Humans, Slimes, Dwarves, Felinids, Vulpkanins, and Harpies should use the Firstname Lastname convention.
-  
+  Humans, Amorphians, Dwarves, Felinids, Vulpkanins, and Harpies should use the Firstname Lastname convention.
+
   Examples
   - [color=#449944]Good:[/color] Tom Fisher
   - [color=#449944]Good:[/color] Spacey Chapman
@@ -30,10 +30,10 @@
   - [color=#994444]Bad:[/color] Ben Dover
   - [color=#994444]Bad:[/color] Mike Hunt
   - [color=#994444]Bad:[/color] Joe Mamma
-  
+
 
   Reptilians should use the "verb-article-noun" or Argonian convention.
- 
+
   Examples
   - [color=#449944]Good:[/color] Cleans-the-Airlocks
   - [color=#449944]Good:[/color] Deekus
@@ -45,28 +45,28 @@
   - [color=#994444]Bad:[/color] Bans-the-Admins
 
   Diona should have calm, nature-themed, Noun of Noun style names.
-  
+
   Examples
   - [color=#449944]Good:[/color] Petal of Tranquility
   - [color=#449944]Good:[/color] Garden of Relaxation
   - [color=#994444]Bad:[/color] Tree but Alive
 
-  Mothmen should use Latin sounding names, light themed names or a moniker usually related to something the person likes or is known for.
-  
+  Lepidopterans should use Latin sounding names, light themed names or a moniker usually related to something the person likes or is known for.
+
   Examples
   - [color=#449944]Good:[/color] Socrates Temnora
   - [color=#449944]Good:[/color] Sierra Lightseeker
   - [color=#449944]Good:[/color] James Nightflitter
   - [color=#449944]Good:[/color] Tulip
-  
+
 
   Arachnids should have Latin-sounding names.
-  
+
   Examples
   - [color=#449944]Good:[/color] Argyroneta Reticulatus
   - [color=#449944]Good:[/color] Loxosceles Domesticus
   - [color=#994444]Bad:[/color] Spider-Man
-  
+
   Vox use a single name made of random syllables, often with repeating patterns.
   Names should not be excessively long or be so repetitive/convoluted as to be unreadable.
 
@@ -77,7 +77,7 @@
   - [color=#994444]Bad:[/color] Trololol
 
 
-  Rodentia naming convention has the first name an descriptor (Strong, Big-eyed, Trash-eating) and the "first" part either being a simple first name or pet name (Monty, Basil, Nibbles). Rondentia names can also simply be a single pet name.
+  Rodentian naming convention has the first name an descriptor (Strong, Big-eyed, Trash-eating) and the "first" part either being a simple first name or pet name (Monty, Basil, Nibbles). Rondentia names can also simply be a single pet name.
 
   Examples
   - [color=#449944]Good:[/color] Big Poppy
@@ -87,7 +87,7 @@
   - [color=#449944]Good:[/color] Rose
 
   Usernames, objects, random characters, very "low effort" names, "meta" names, or otherwise implausible names are not permitted.
-  
+
   Examples
   - [color=#994444]Bad:[/color] XxRobustxX
   - [color=#994444]Bad:[/color] SDpksSodjdfk

--- a/Resources/ServerInfo/_Goobstation/Guidebook/Antagonist/Changelings.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/Antagonist/Changelings.xml
@@ -30,7 +30,7 @@
   You can only have a maximum of 5 DNA strands at a time, and must transform to obtain more.
 
   Acquiring DNA via absorption requires the victim's incapacitation, critical condition or death. Simply, handcuff, put him into crit or kill him if you need to absorb him.
-  
+
   - Absorbing someone takes a lot of time, so prepare a safe spot or do it somewhere with the least amount of ears possible.
   - Absorbing a victim will recover all of your biomass, increase your maximum chemical capacity and give you bonus evolution points to buy new abilities.
   - Absorbing another changeling will, on top of that, increase your maximum biomass capacity, allowing you to stay alive for more time and give you even more chemicals and evolution points.
@@ -41,7 +41,7 @@
   The changeling can shift its appearance, making them look and sound exactly like a victim of which they have absorbed. This can be massive compromise in security, especially if command staff are absorbed and the changeling is able to imitate them.
   Changelings can also, via their lesser form ability, transform into monkeys and do monkey things.
 
-  
+
   ### Regeneration
   Also known as Regenerative Stasis, changelings have the ability to 'kill' themselves, and appear dead. After an uncertain amount of time, the changeling can revive at will, fully healed of all injuries and illness.
   Entering stasis drains all of the changeling's chemicals, and leaving costs 60. Chemicals will still regenerate while a changeling is dead, meaning it can always enter stasis unless it's biomass levels are critical.
@@ -55,7 +55,7 @@
   Even so, [colopr=red]a coordinated group of changelings is truly a terror to behold[/color].
 
   ## Identifying a changeling
-  Changelings have a different blood type. Even if a changeling is pretending to be a diona, vox or a moth person, they have one blood type.
+  Changelings have a different blood type. Even if a changeling is pretending to be a diona, vox or a lepidopteran, they have one blood type.
   Also, when put in a centrifuge, the changeling's blood reacts violently.
   You cannot identify changelings in any other possible way, unless they're dead obvious and start going loud.
 </Document>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Moth people, Slime people and Rodentia are now called Lepidopterans, Amorphians and Rodentians respectively.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Moth and Slime people is just so incredibly uninspired - and 'Rodentia' doesn't sound right referring to a collective of people; yes, it's the valid scientific species name but all other species are named for their collectives, not their genuses (Humans, not Homo Sapiens, etc)

## Technical details
<!-- Summary of code changes for easier review. -->
Changed the .ftl and guidebook entries to the new names. The internal names are unchanged because changing them all would be incredibly stupid for so many reasons. It's purely a visual change.
