### PR TITLE
Little 'a' for pizza parties.

### DIFF
--- a/Resources/Locale/en-US/station-events/events/cargo-gifts.ftl
+++ b/Resources/Locale/en-US/station-events/events/cargo-gifts.ftl
@@ -10,8 +10,8 @@ cargo-gift-dest-janitor = Service Dept
 cargo-gift-dest-med = Medical Dept
 cargo-gift-dest-sec = Security Dept
 
-cargo-gift-pizza-small = A small pizza party
-cargo-gift-pizza-large = A large pizza party
+cargo-gift-pizza-small = a small pizza party
+cargo-gift-pizza-large = a large pizza party
 
 cargo-gift-eng = Repair Materials
 cargo-gift-vending = Vending machines refills


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed the .ftl strings for the pizza party gift notification to use a small 'a' and not a capital 'A'.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The old string meant that the message read as 'NanoTrasen has decided to send A small pizza party' which looks duuumb.

## Technical details
<!-- Summary of code changes for easier review. -->
Hit the capital A with a koopa shell, causing it to lose it's Super Mushroom power-up and reduce back down to small a.
