### PR TITLE
Moved pins to their own tab and added some new trinkets/requirements

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -3,6 +3,7 @@ loadout-group-species-restriction = This item is not available for your current 
 
 # Miscellaneous
 loadout-group-trinkets = Trinkets
+loadout-group-pins = Pins
 loadout-group-glasses = Glasses
 loadout-group-backpack = Backpack
 loadout-group-instruments = Instruments

--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -6,7 +6,34 @@
     requirement:
       !type:DepartmentTimeRequirement
       department: Command
-      time: 3600 # 1 hour
+      time: 14400 # 4 hrs
+
+- type: loadoutEffectGroup
+  id: Medical
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Medical
+      time: 14400 # 4 hrs
+
+- type: loadoutEffectGroup
+  id: Science
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Science
+      time: 14400 # 4 hrs
+
+- type: loadoutEffectGroup
+  id: Engineering
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Engineering
+      time: 14400 # 4 hrs
 
 # Flowers
 - type: loadout
@@ -34,12 +61,48 @@
     back:
     - PlushieSpaceLizard
 
+- type: loadout
+  id: PlushieSharkBlue
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: Medical
+  storage:
+    back:
+    - PlushieSharkBlue
+
+- type: loadout
+  id: PlushieSharkPink
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: Engineering
+  storage:
+    back:
+    - PlushieSharkPink
+
+- type: loadout
+  id: PlushieSharkGrey
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: Science
+  storage:
+    back:
+    - PlushieSharkGrey
+
 # Smokeables
 - type: loadout
   id: Lighter
   storage:
     back:
     - Lighter
+
+- type: loadout
+  id: FlippoLighter
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: Command
+  storage:
+    back:
+    - FlippoLighter
 
 - type: loadout
   id: CigPackGreen
@@ -73,15 +136,6 @@
   storage:
     back:
     - CigarCase
-
-- type: loadout
-  id: CigarGold
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: Command
-  storage:
-    back:
-    - CigarGold
 
 # Pins
 - type: loadout

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -9,13 +9,23 @@
   - Hairflower
   - PlushieLizard
   - PlushieSpaceLizard
+  - PlushieSharkBlue
+  - PlushieSharkPink
+  - PlushieSharkGrey
   - Lighter
+  - FlippoLighter
   - CigPackGreen
   - CigPackRed
   - CigPackBlue
   - CigPackBlack
   - CigarCase
-  - CigarGold
+
+- type: loadoutGroup
+  id: Pins
+  name: loadout-group-pins
+  minLimit: 0
+  maxLimit: 1
+  loadouts:
   - ClothingNeckLGBTPin
   - ClothingNeckAromanticPin
   - ClothingNeckAsexualPin

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -9,6 +9,7 @@
   - CaptainOuterClothing
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -23,6 +24,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 # Silicons
@@ -45,6 +47,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -58,6 +61,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -69,6 +73,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -83,6 +88,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -94,6 +100,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -106,6 +113,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -121,6 +129,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -135,6 +144,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - JanitorPlunger
   - GroupSpeciesBreathTool
 
@@ -149,6 +159,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -163,6 +174,7 @@
   - Glasses
   - SurvivalClown
   - Trinkets
+  - Pins
 
 - type: roleLoadout
   id: JobMime
@@ -177,6 +189,7 @@
   - Glasses
   - SurvivalMime
   - Trinkets
+  - Pins
 
 - type: roleLoadout
   id: JobMusician
@@ -188,6 +201,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - Instruments
   - GroupSpeciesBreathTool
 
@@ -205,6 +219,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -219,6 +234,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -231,6 +247,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 # Engineering
@@ -246,6 +263,7 @@
   - ChiefEngineerShoes
   - SurvivalExtended
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -256,6 +274,7 @@
   - StationEngineerBackpack
   - SurvivalExtended
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -270,6 +289,7 @@
   - StationEngineerID
   - SurvivalExtended
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -283,6 +303,7 @@
   - AtmosphericTechnicianShoes
   - SurvivalExtended
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 # Science
@@ -300,6 +321,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -317,6 +339,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -328,6 +351,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 # Security
@@ -343,6 +367,7 @@
   - SecurityShoes
   - SurvivalSecurity
   - Trinkets
+  - Pins
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
 
@@ -357,6 +382,7 @@
   - SecurityShoes
   - SurvivalSecurity
   - Trinkets
+  - Pins
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
 
@@ -372,6 +398,7 @@
   - SecurityBelt
   - SurvivalSecurity
   - Trinkets
+  - Pins
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
 
@@ -387,6 +414,7 @@
   - SecurityShoes
   - SurvivalSecurity
   - Trinkets
+  - Pins
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
 
@@ -398,6 +426,7 @@
   - SurvivalSecurity
   - SecurityOuterClothing # Goobstation - Why not.
   - Trinkets
+  - Pins
   - GroupSpeciesBreathToolSecurity
 
 # Medical
@@ -416,6 +445,7 @@
   - Glasses
   - SurvivalMedical
   - Trinkets
+  - Pins
   - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
@@ -433,6 +463,7 @@
   - Glasses
   - SurvivalMedical
   - Trinkets
+  - Pins
   - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
@@ -444,6 +475,7 @@
   - Glasses
   - SurvivalMedical
   - Trinkets
+  - Pins
   - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
@@ -458,6 +490,7 @@
   - MedicalShoes
   - SurvivalMedical
   - Trinkets
+  - Pins
   - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
@@ -474,6 +507,7 @@
   - Glasses
   - SurvivalMedical
   - Trinkets
+  - Pins
   - GroupSpeciesBreathToolMedical
 
 # Wildcards
@@ -485,6 +519,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -497,6 +532,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 
@@ -509,6 +545,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -521,6 +558,7 @@
   - Glasses
   - Survival
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
 
 # These loadouts are used for non-crew spawns, like off-station antags and event mobs

--- a/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
@@ -8,6 +8,7 @@
   - NanotrasenRepresentativeBelt
   - Glasses
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
   - Survival
 
@@ -19,5 +20,6 @@
   - BlueshieldOfficerOuter
   - BlueshieldOfficerNeck
   - Trinkets
+  - Pins
   - GroupSpeciesBreathTool
   - Survival


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Moves all the identity and representation pins to their own 'Pins' category in the loadouts, and adds a few new trinkets and requirements.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The pins dominated the trinkets, adding more entries would oversaturate the list. Personally I don't know how many people actually pick a pin for their loadouts BUT rather than remove them entirely, which would be in bad taste, moving them to a dedicated category preserves them and tidies up the lists a little. It also technically means you can have three trinkets and one pin, so you get more bang for your buck!

## Technical details
<!-- Summary of code changes for easier review. -->
Created the 'Pins' loadout category and split the identity/representation pins out from the Trinkets and moved them into the new category. Also added three new department playtime requirements and used them on the new trinkets. Plan to add a few more in the future~
