### PR TITLE
Allows artifacts to be anchored on top (but cannot be scanned)

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
@@ -28,14 +28,6 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-0.35,-0.35,0.35,0.35"
-        mask:
-        - Impassable
-        - HighImpassable
-        - MidImpassable
-      fix2:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.35,-0.35,0.35,0.35"
         density: 190
         mask:
         - MachineMask


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed a little bit of fixtures definition in the analyzer prototype to allow for artifacts to be anchored while on top.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's annoying to have to move them off the platform to do tool usage. Anchored artifacts cannot be scanned, however, so artifacts that are moving around still need to be boxed in, but this can also help with that.

## Technical details
<!-- Summary of code changes for easier review. -->
Uuuuh removed one of the fixtures definitions that for some reason was blocking the ability to wrench down artifacts.
