### PR TITLE
Use locale string for lobby title in UI

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -49,7 +49,7 @@ namespace Content.Client.Lobby
 
             _voteManager.SetPopupContainer(Lobby.VoteContainer);
             LayoutContainer.SetAnchorPreset(Lobby, LayoutContainer.LayoutPreset.Wide);
-            Lobby.ServerName.Text = _baseClient.GameInfo?.ServerName; //The eye of refactor gazes upon you...
+            Lobby.ServerName.Text = Loc.GetString("ui-lobby-server-name"); //The eye of refactor gazes upon you...
             UpdateLobbyUi();
 
             Lobby.CharacterPreview.CharacterSetupButton.OnPressed += OnSetupPressed;

--- a/Resources/Locale/en-US/lobby/lobby-gui.ftl
+++ b/Resources/Locale/en-US/lobby/lobby-gui.ftl
@@ -1,4 +1,5 @@
-﻿ui-lobby-title = Lobby
+﻿ui-lobby-title = Welcome to
+ui-lobby-server-name = ShibaStation ~ 🐕
 ui-lobby-ahelp-button = AHelp
 ui-lobby-options-button = Options
 ui-lobby-leave-button = Leave


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed how the Lobby UI grabs the title from the hostname to a locale string

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
If you happen to have an exceptionally long hostname for various reasons, it makes the lobby UI really wide and kinda ugly, this instead allows you to set a different name in the relevant locale file.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed how the lobby hostname is gotten from the actual hostname to a locale string, allowing for separated names and ideally truncation.