### PR TITLE
Added missing ore tag to bluespace crystals

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Materials/materials.yml
@@ -28,6 +28,9 @@
     radius:
       min: 2
       max: 5
+  - type: Tag
+    tags:
+    - Ore
 
 - type: entity
   parent: MaterialBSCrystal


### PR DESCRIPTION
This is approved on Goob upstream but still not merged and I'm impatient :)