### PR TITLE
EE Harpy Update Tweaks

### DIFF
--- a/Content.Server/_EinsteinEngines/Flight/FlightSystem.cs
+++ b/Content.Server/_EinsteinEngines/Flight/FlightSystem.cs
@@ -2,6 +2,8 @@
 using Content.Shared.Bed.Sleep;
 using Content.Shared.Cuffs.Components;
 using Content.Shared.Damage.Components;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.DoAfter;
 using Content.Shared._EinsteinEngines.Flight;
 using Content.Shared._EinsteinEngines.Flight.Events;
@@ -19,6 +21,7 @@ public sealed class FlightSystem : SharedFlightSystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
+    [Dependency] private readonly HungerSystem _hungerSystem = default!; // ShibaStation - Used to check current hunger threshold for flight.
 
     public override void Initialize()
     {
@@ -113,6 +116,12 @@ public sealed class FlightSystem : SharedFlightSystem
             _popupSystem.PopupEntity(Loc.GetString("no-flight-while-lying"), uid, uid, PopupType.Medium);
             return false;
         }
+        if (TryComp<HungerComponent>(uid, out var hunger) && _hungerSystem.GetHungerThreshold(hunger) == HungerThreshold.Starving) // ShibaStation - No flight while starving.
+        {
+            _popupSystem.PopupEntity(Loc.GetString("no-flight-while-starving"), uid, uid, PopupType.Medium);
+            return false;
+        }
+
         return true;
     }
 

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -538,4 +538,13 @@ public sealed class PullingSystem : EntitySystem
         StopPulling(pullableUid, pullable);
         return true;
     }
+
+    /// <summary>
+    /// Shibastation -Toggles whether the entity needs hands to pull or not.
+    /// </summary>
+    public void ToggleHandsFree(EntityUid uid, bool free)
+    {
+        if (TryComp<PullerComponent>(uid, out var puller))
+            puller.NeedsHands = !free;
+    }
 }

--- a/Content.Shared/_EinsteinEngines/Flight/FlightComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Flight/FlightComponent.cs
@@ -28,19 +28,19 @@ public sealed partial class FlightComponent : Component
     ///     Stamina drain per second when flying
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float StaminaDrainRate = 0.0f; // ShibaStation - No stamina drain, to be replaced with hunger/thirst drain instead.
+    public float StaminaDrainRate = 0.0f; // ShibaStation - No stamina drain, to be replaced with hunger drain instead.
 
     /// <summary>
-    ///     Hunger and thirst drain per second when flying
+    ///     Hunger drain per second when flying
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float HungerThirstDrainRate = 1.0f; // ShibaStation - No hunger/thirst drain, to be replaced with stamina drain instead.
+    public float HungerDrainRate = 1.5f; // ShibaStation - Drain hunger by this amount every time hunger updates.
 
     /// <summary>
     ///     DoAfter delay until the user becomes weightless.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float ActivationDelay = 0.5f; // ShibaStation - Greatly reduced activation delay, birds take off quickly, but harpies need to stand still first.
+    public float ActivationDelay = 0.0f; // ShibaStation - Instant takeoff, fuck it we ball.
 
     /// <summary>
     ///     Speed modifier while in flight

--- a/Content.Shared/_EinsteinEngines/Flight/FlightComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Flight/FlightComponent.cs
@@ -28,13 +28,19 @@ public sealed partial class FlightComponent : Component
     ///     Stamina drain per second when flying
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float StaminaDrainRate = 6.0f;
+    public float StaminaDrainRate = 0.0f; // ShibaStation - No stamina drain, to be replaced with hunger/thirst drain instead.
+
+    /// <summary>
+    ///     Hunger and thirst drain per second when flying
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float HungerThirstDrainRate = 1.0f; // ShibaStation - No hunger/thirst drain, to be replaced with stamina drain instead.
 
     /// <summary>
     ///     DoAfter delay until the user becomes weightless.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float ActivationDelay = 1.0f;
+    public float ActivationDelay = 0.5f; // ShibaStation - Greatly reduced activation delay, birds take off quickly, but harpies need to stand still first.
 
     /// <summary>
     ///     Speed modifier while in flight

--- a/Content.Shared/_EinsteinEngines/Flight/SharedFlightSystem.cs
+++ b/Content.Shared/_EinsteinEngines/Flight/SharedFlightSystem.cs
@@ -1,6 +1,6 @@
 using Content.Shared.Actions;
 using Content.Shared.Movement.Systems;
-using Content.Shared.Damage.Systems;
+// using Content.Shared.Damage.Systems; # ShibaStation - No stamina drain instead we use hunger drain.
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction.Components;
@@ -12,7 +12,7 @@ public abstract class SharedFlightSystem : EntitySystem
 {
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
     [Dependency] private readonly SharedVirtualItemSystem _virtualItem = default!;
-    [Dependency] private readonly StaminaSystem _staminaSystem = default!;
+    // [Dependency] private readonly StaminaSystem _staminaSystem = default!; // ShibaStation - No stamina drain, to be replaced with hunger drain instead.
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
 
@@ -44,7 +44,7 @@ public abstract class SharedFlightSystem : EntitySystem
         component.TimeUntilFlap = 0f;
         _actionsSystem.SetToggled(component.ToggleActionEntity, component.On);
         RaiseNetworkEvent(new FlightEvent(GetNetEntity(uid), component.On, component.IsAnimated));
-        _staminaSystem.ToggleStaminaDrain(uid, component.StaminaDrainRate, active, false);
+        // _staminaSystem.ToggleStaminaDrain(uid, component.StaminaDrainRate, active, false); # ShibaStation - No stamina drain, to be replaced with hunger/thirst drain instead.
         _movementSpeed.RefreshMovementSpeedModifiers(uid);
         UpdateHands(uid, active);
         Dirty(uid, component);

--- a/Resources/Changelog/ShibaChangelog.yml
+++ b/Resources/Changelog/ShibaChangelog.yml
@@ -1,6 +1,26 @@
 Entries:
 - author: AstroDogeDX
   changes:
+  - message: Flying harpies can pull entities despite having occupied hands, by using
+      their talons, of course! They use their hands (wings?) when not flying, still.
+    type: Add
+  id: 33
+  time: '2024-12-06T11:01:35.877245'
+- author: AstroDogeDX
+  changes:
+  - message: Harpies now drain hunger instead of stamina to fly, and can't fly/stop
+      flying if they're starving.
+    type: Tweak
+  id: 32
+  time: '2024-12-06T11:01:06.821933'
+- author: AstroDogeDX
+  changes:
+  - message: Harpies take off to fly instantly now.
+    type: Tweak
+  id: 31
+  time: '2024-12-06T11:00:19.762857'
+- author: AstroDogeDX
+  changes:
   - message: (re)Added shock collars to the security lockers. ( ͡° ͜ʖ ͡°)
     type: Add
   id: 30

--- a/Resources/Locale/en-US/_ShibaStation/flight/flight_system.ftl
+++ b/Resources/Locale/en-US/_ShibaStation/flight/flight_system.ftl
@@ -1,0 +1,1 @@
+no-flight-while-starving = You are too hungry to fly right now.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Harpy flight now consumes hunger instead of stamina, allowing for longer flights but with potentially worse consequences for resource mismanagement. Additionally they can pull while flying (using their talons, like lizzers with their tails), and take off instantly (this may be changed later).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A species of flying creatures that can only fly for a few seconds before collapsing on the floor is incredibly dumb. Hunger drain is quite high (subject to change) but still permits about a minute of flight for a round-start harpy. For balance, though, being starving (which stops flight and doesn't allow flight) has its own risks due to the movement debuff, but managing hunger means harpy players can better utilise their new ability.

Pulling while flying lets harpies utilise their flight ability more, for example, pulling bodies away while flying to avoid slippables (there's still a speed debuff while dragging).

Instant takeoff mimics jetpack activation and speedboots. Have you seen how fast birds take off, dude? It's pretty fast. This MIGHT be changed in the future, though.

## Technical details
<!-- Summary of code changes for easier review. -->
Added hunger deductions based on current flight status to the `HungerSystem`
Added a way to toggle `NeedsHands` in the `PullerComponent` into the `PullingSystem`
Used aformentioned toggle in the `SharedFlightSystem` to enable/disable handsfree pulling depending on flight status
Added check to flight if hunger threshold is below Peckish (so Starving) in `FlightSystem`
Commented and zeroed out anything related to stamina drain (didn't remove the code, though)
Added hunger drain value to the `FlightComponent` as a flat-rate deduction to the hunger value. Configurable!
