### PR TITLE
Increase Ore Stacks from 30 to 50

### DIFF
--- a/Resources/Changelog/ShibaChangelog.yml
+++ b/Resources/Changelog/ShibaChangelog.yml
@@ -1,6 +1,12 @@
 Entries:
 - author: AstroDogeDX
   changes:
+  - message: Stack sizes for ores have been increased from 30 to 50.
+    type: Tweak
+  id: 34
+  time: '2024-12-06T11:16:35.049522'
+- author: AstroDogeDX
+  changes:
   - message: Flying harpies can pull entities despite having occupied hands, by using
       their talons, of course! They use their hands (wings?) when not flying, still.
     type: Add

--- a/Resources/Prototypes/Stacks/Materials/ore.yml
+++ b/Resources/Prototypes/Stacks/Materials/ore.yml
@@ -3,49 +3,49 @@
   name: gold ore
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: gold }
   spawn: GoldOre1
-  maxCount: 30
-  
+  maxCount: 50 # Shibastation - Increased from 30 to 50.
+
 - type: stack
   id: DiamondOre
   name: rough diamond
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: diamond }
   spawn: DiamondOre1
-  maxCount: 30
+  maxCount: 50 # Shibastation - Increased from 30 to 50.
 
 - type: stack
   id: SteelOre
   name: iron ore
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: iron }
   spawn: SteelOre1
-  maxCount: 30
+  maxCount: 50 # Shibastation - Increased from 30 to 50.
 
 - type: stack
   id: PlasmaOre
   name: plasma ore
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: plasma }
   spawn: PlasmaOre1
-  maxCount: 30
+  maxCount: 50 # Shibastation - Increased from 30 to 50.
 
 - type: stack
   id: SilverOre
   name: silver ore
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: silver }
   spawn: SilverOre1
-  maxCount: 30
+  maxCount: 50 # Shibastation - Increased from 30 to 50.
 
 - type: stack
   id: SpaceQuartz
   name: space quartz
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: spacequartz }
   spawn: SpaceQuartz1
-  maxCount: 30
+  maxCount: 50 # Shibastation - Increased from 30 to 50.
 
 - type: stack
   id: UraniumOre
   name: uranium ore
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: uranium }
   spawn: UraniumOre1
-  maxCount: 30
+  maxCount: 50 # Shibastation - Increased from 30 to 50.
 
 
 - type: stack
@@ -53,18 +53,18 @@
   name: bananium ore
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: bananium }
   spawn: BananiumOre1
-  maxCount: 30
+  maxCount: 50 # Shibastation - Increased from 30 to 50.
 
 - type: stack
   id: Coal
   name: coal
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: coal }
   spawn: Coal1
-  maxCount: 30
+  maxCount: 50 # Shibastation - Increased from 30 to 50.
 
 - type: stack
   id: SaltOre
   name: salt
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: salt }
   spawn: Salt1
-  maxCount: 30
+  maxCount: 50 # Shibastation - Increased from 30 to 50.

--- a/Resources/Prototypes/_Goobstation/Stacks/Materials/materials.yml
+++ b/Resources/Prototypes/_Goobstation/Stacks/Materials/materials.yml
@@ -3,4 +3,4 @@
   name: bluespace crystal
   icon: { sprite: /Textures/_Goobstation/Objects/Materials/materials.rsi, state: bluespace_crystal }
   spawn: MaterialBSCrystal1
-  maxCount: 30
+  maxCount: 50 # Shibastation - Increased from 30 to 50.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Increased ore stack sizes from 30 to 50.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Goob increased (by reverting a WizDen change) ore distribution, meaning more ores to mine. I didn't want to increase the stack too much and invalidate getting the Ore Bag of Holding but a slight bump to ore stacks should hopefully keep average mining sessions about the same length. A reduction in tedium means the station should benefit sooner, hopefully!

## Technical details
<!-- Summary of code changes for easier review. -->
Increased the stack count for every ore entry (and bluespace crystals) from 30 to 50.