### PR TITLE
Fixed Emote Jank

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -239,6 +239,7 @@
     - DoorBumpOpener
     - FootstepSound
     - CanPilot
+    - BorgEmotes # ShibaStation - Emote Whitelist
   - type: Emoting
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -327,6 +327,10 @@
   name: chat-emote-name-buzz
   category: Vocal
   icon: Interface/Emotes/buzz.png
+  whitelist:
+    tags:
+    - BorgEmotes
+    - HarpyEmotes
   chatMessages: ["chat-emote-msg-buzz"]
   chatTriggers:
     - buzzing
@@ -341,6 +345,11 @@
   available: false
   icon: Interface/Emotes/weh.png
   chatMessages: [wehs]
+  chatTriggers:
+    - weh
+    - wehs
+    - wehing
+    - wehed
 
 - type: emote
   id: Chirp
@@ -366,6 +375,11 @@
   name: chat-emote-name-beep
   category: Vocal
   icon: Interface/Emotes/beep.png
+  whitelist:
+    tags:
+    - BorgEmotes
+    - HarpyEmotes
+    - IPCEmotes
   chatMessages: ["chat-emote-msg-beep"]
   chatTriggers:
     - beep
@@ -378,6 +392,11 @@
   name: chat-emote-name-chime
   category: Vocal
   icon: Interface/Emotes/chime.png
+  whitelist:
+    tags:
+    - BorgEmotes
+    - HarpyEmotes
+    - IPCEmotes
   chatMessages: ["chat-emote-msg-chime"]
   chatTriggers:
     - chime
@@ -390,6 +409,11 @@
   name: chat-emote-name-buzztwo
   category: Vocal
   icon: Interface/Emotes/buzztwo.png
+  whitelist:
+    tags:
+    - BorgEmotes
+    - HarpyEmotes
+    - IPCEmotes
   chatMessages: ["chat-emote-msg-buzzestwo"]
   chatTriggers:
     - buzztwice
@@ -408,6 +432,11 @@
   name: chat-emote-name-ping
   category: Vocal
   icon: Interface/Emotes/ping.png
+  whitelist:
+    tags:
+    - BorgEmotes
+    - HarpyEmotes
+    - IPCEmotes
   chatMessages: ["chat-emote-msg-ping"]
   chatTriggers:
     - ping

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -181,6 +181,7 @@
         - CanPilot
         - FootstepSound
         - DoorBumpOpener
+        - IPCEmotes # ShibaStation - Emote Whitelist
     - type: Hands
     - type: Inventory
       templateId: human

--- a/Resources/Prototypes/_EinsteinEngines/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Voice/speech_emotes.yml
@@ -10,13 +10,18 @@
   id: Boop
   name: chat-emote-name-boop
   category: Vocal
-  chatMessages: [ boops ]
+  icon: Interface/Emotes/beep.png # ShibaStation - Icon
+  whitelist: # ShibaStation - Whitelist
+    tags:
+    - IPCEmotes
+    - HarpyEmotes
+  chatMessages: [ boops! ]
   chatTriggers:
     - boops
 
 - type: emote
   id: Whirr # uncategorized as it is generic
   name: chat-emote-name-whirr
-  chatMessages: [ whirrs ]
+  chatMessages: [ whirrs! ]
   chatTriggers:
     - whirrs

--- a/Resources/Prototypes/_ShibaStation/tags.yml
+++ b/Resources/Prototypes/_ShibaStation/tags.yml
@@ -18,3 +18,9 @@
 
 - type: Tag
   id: ReptilianEmotes
+
+- type: Tag
+  id: BorgEmotes
+
+- type: Tag
+  id: IPCEmotes


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added new tags for species specific emotes and whitelisted the speech emotes accordingly, to fix unusable emotes appearing in the emote wheel UI. Also gave IPC boop an icon (reused the beep icon for borgs) and fixed our lizzers not being able to weh on command.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Lizzers need to weh. Also the UI stuff annoyed me.

## Technical details
<!-- Summary of code changes for easier review. -->
Bruh look at the diffs?
