### PR TITLE
Cleanbots can move under doors and tables

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -312,6 +312,17 @@
     size: Large
   - type: StationAiVision # Goobstation - AI can see through NT silicon
     range: 0
+  - type: Fixtures # ShibaStation - let cleanbots go under doors and tables to clean!
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.35
+        density: 50
+        mask:
+        - SmallMobMask
+        layer:
+        - SmallMobLayer
 
 - type: entity
   parent:


### PR DESCRIPTION
Jani meta just saw an upset, cleanbot meta is the new meta.

but fr this actually solves a few issues of cleanbots being dumb and getting hung up trying to clean a spot under a door or table and ignoring the rest of the messes until intervened. It's not *perfect* but it's BETTER.