### PR TITLE
Lootbugs are vermin

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
@@ -228,3 +228,6 @@
   - type: Butcherable
     spawned:
     - id: SpawnLootLootbug
+  - type: NpcFactionMember # they're pests, makes them the target of shiva and aves
+    factions:
+      - Mouse

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
@@ -230,4 +230,4 @@
     - id: SpawnLootLootbug
   - type: NpcFactionMember # they're pests, makes them the target of shiva and aves
     factions:
-      - Xeno # since they're a bit tankier than most pests, and can fight back, xeno seems more appropriate (like spiders)
+      - Mouse

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
@@ -230,4 +230,4 @@
     - id: SpawnLootLootbug
   - type: NpcFactionMember # they're pests, makes them the target of shiva and aves
     factions:
-      - Mouse
+      - Xeno # since they're a bit tankier than most pests, and can fight back, xeno seems more appropriate (like spiders)


### PR DESCRIPTION
Makes loot bugs be recognised in the `Mouse` faction, making them targets for Shiva, Aves and now Pun Pun. They're a pest that spawns with other non-hostile vent critters, but if ghost role'd they *can* be dangerous, but by nature they seem less interested in attacking crew, so NPC behaviour being 'docile' and ghost behaviour being free agent (and thus potentially hostile) seems fine to me.