### PR TITLE
Nerfed lootbug health and damage.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
@@ -217,7 +217,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Dead
+      40: Critical # ShibaStation - Unrobust the lootbug
+      60: Dead # ShibaStation - Unrobust the lootbug
   - type: Bloodstream
     bloodReagent: InsectBlood
     bloodMaxVolume: 40
@@ -231,3 +232,9 @@
   - type: NpcFactionMember # they're pests, makes them the target of shiva and aves
     factions:
       - Mouse
+  - type: MeleeWeapon # ShibaStation - Ghost role lootbugs can still be shitters, just not as much anymore :)
+    angle: 0
+    animation: WeaponArcBite
+    damage:
+      types:
+        Piercing: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Nerfed lootbugs; sorry not sorry shitters

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Lootbugs are incredibly robust for what is non hostile rare critter spawn. They were more tanky than spiders and just a little less tanky than slimes but without the water weakness. This also made them lucrative for ghost role shitter players (you know who you are). We are a no fun allowed fork >:)

## Technical details
<!-- Summary of code changes for easier review. -->
Gave lootbugs the same damage thresholds (alive 0, crit 40, dead 60) as mothroaches.
Reduced lootbug bite damage to 2 (piercing)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
bug but deader
