### PR TITLE
Removed Space Cobras from the vent spawns

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -392,8 +392,8 @@
       prob: 0.02
     - id: MobSmallPurpleSnake
       prob: 0.02
-    - id: MobCobraSpace
-      prob: 0.02
+    # - id: MobCobraSpace # ShibaStation - No longer spawns free stealth glands
+    #   prob: 0.02
 
 - type: entity
   id: SpiderSpawn


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Space Cobras are no longer included in the Snake Vent Spawn event.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Shitmed added cobra glands which grant stealth to anyone implanted with them. That's cool and all but now that we've made vent critter spawns a regular event, I don't think the station should have easy access to stealth camo when there's enough players. Salvagers should be bringing back exotic organs instead.

## Technical details
<!-- Summary of code changes for easier review. -->
Commented out the Space Cobras from the event mob probability chance bit in the prototype

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Imagine space cobras but not.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
