### PR TITLE
Emotes ending in tildes now work properly

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.Emote.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Emote.cs
@@ -174,13 +174,13 @@ public partial class ChatSystem
         static string TrimPunctuation(string textInput)
         {
             var trimEnd = textInput.Length;
-            while (trimEnd > 0 && char.IsPunctuation(textInput[trimEnd - 1]))
+            while (trimEnd > 0 && (char.IsPunctuation(textInput[trimEnd - 1]) || textInput[trimEnd - 1] == '~'))
             {
                 trimEnd--;
             }
 
             var trimStart = 0;
-            while (trimStart < trimEnd && char.IsPunctuation(textInput[trimStart]))
+            while (trimStart < trimEnd && (char.IsPunctuation(textInput[trimStart]) || textInput[trimStart] == '~'))
             {
                 trimStart++;
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added an additional check to the emotes system to treat tildes (~) as punctuation, thus allowing emotes to work properly if they end with one.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
uwu emotes on you~

## Technical details
<!-- Summary of code changes for easier review. -->
Just added an additional check for a ~ along with the standard C# punctuation check.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
too lazy, it works as explained.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Emotes ending in tildes~ now work!

