### PR TITLE
Gives chemist access to botany and service under extended access

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -16,6 +16,8 @@
   - Maintenance
   extendedAccess:
   - Research # ShibaStation - Added Research to Chemist access
+  - Hydroponics # ShibaStation - Added Hydroponics to Chemist access
+  - Service # ShibaStation - Added Service to Chemist access
   # Shitmed Change
   special:
   - !type:AddComponentSpecial


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Gives chemists access to service and botany under the extended access system.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Chems and botanists usually work hand in hand, but during low pop, sometimes chems might not have a botanist to bounce off. This means chems with botany knowledge can do double duty (should they wish) without needing to be granted access from HoP or other command.

## Technical details
<!-- Summary of code changes for easier review. -->
Added Hydroponics and Service to Chemists extended access.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
A chemist walks into botany and says; "kudzu grow me some plants and I'll leave you aloe".

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Chemists now get access to Botany (and Service) during Extended Access (low pop).