### PR TITLE
Prevent aghosts from leaving access logs

### DIFF
--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -395,6 +395,11 @@ public sealed class AccessReaderSystem : EntitySystem
         if (IsPaused(ent) || ent.Comp.LoggingDisabled)
             return;
 
+        // Check if the accessor has a Universal ID and skip logging if they do
+        var accessTags = FindAccessTags(accessor);
+        if (accessTags.Any(tag => tag == "CentralCommand"))
+            return;
+
         string? name = null;
         if (TryComp<NameIdentifierComponent>(accessor, out var nameIdentifier))
             name = nameIdentifier.FullIdentifier;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added an early return if the door access is done by an entity with the 'CentralCommand' access role (Admins and CC).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Log Probe was reporting back when aghosts had interacted with stuff, which can cause confusion if the admin is also in the game in character, but had to aghost to check/interact with something. Creates false positives, even if it does append the access with the (Universal) suffix.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a check for the 'CentralCommand' access role on the entity's ID and if so, early returns and doesn't log the access attempt. 
