### PR TITLE
Robust Harpy Lungs

### DIFF
--- a/Resources/Prototypes/_DV/Body/Organs/harpy.yml
+++ b/Resources/Prototypes/_DV/Body/Organs/harpy.yml
@@ -12,14 +12,14 @@
   - type: Organ
     slotId: lungs
   - type: Metabolizer
-    updateInterval: 2.0
+    # updateInterval: 2.0 # ShibaStation - Should stop harpies from choking on their own CO2
     removeEmpty: true
     solutionOnBody: false
     solution: "Lung"
     metabolizerTypes: [ Human ]
     groups:
     - id: Gas
-      rateModifier: 200.0
+      rateModifier: 100.0
   - type: SolutionContainerManager
     solutions:
       organ:


### PR DESCRIPTION
The whole harpy lung gimmick is just annoying when they spend all shift choking on their own CO2. Now they breathe like humans. The footwear debuff is enough balancing for Harpies where they don't also need to be suffocating by merely existing.