### PR TITLE
Fix fucking antags (again)

### DIFF
--- a/Content.Shared/GameTicking/Components/GameRuleComponent.cs
+++ b/Content.Shared/GameTicking/Components/GameRuleComponent.cs
@@ -28,7 +28,7 @@ public sealed partial class GameRuleComponent : Component
     /// If false, it will simply not run silently.
     /// </summary>
     [DataField]
-    public bool CancelPresetOnTooFewPlayers = true;
+    public bool CancelPresetOnTooFewPlayers = false; // ShibaStation - stop rounds from failing due to low player readiness. PLEASE STOP THE HERETIC FROM BREAKING THE LOBBY.
 
     /// <summary>
     /// A delay for when the rule the is started and when the starting logic actually runs.

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -4,7 +4,7 @@
   components:
   - type: ChangelingRule
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 10 # ShibaStation - maybe make lings a bit more frequent on low player counts.
   - type: AntagObjectives
     objectives:
     - ChangelingStealDNAObjective
@@ -16,7 +16,7 @@
     definitions:
     - prefRoles: [ Changeling ]
       max: 4
-      playerRatio: 10 # ShibaStation - attempt to fix changeling from FAILING due to lower player averages. Goob, we don't all pull 85 players max at all.
+      playerRatio: 10 # ShibaStation
       lateJoinAdditional: true
       mindRoles:
       - MindRoleChangeling

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -4,7 +4,7 @@
   components:
   - type: HereticRule
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 10 # ShibaStation - maybe make tics a bit more frequent on low player counts.
   - type: AntagObjectives
     objectives:
     - HereticKnowledgeObjective
@@ -16,7 +16,7 @@
     definitions:
     - prefRoles: [ Heretic ]
       max: 5
-      playerRatio: 10 # ShibaStation - attempt to fix heretic from FAILING due to lower player averages. Goob, we don't all pull 85 players max at all.
+      playerRatio: 10 # ShibaStation
       lateJoinAdditional: true
       mindRoles:
       - MindRoleHeretic


### PR DESCRIPTION
flipped a bool from true to false in a desperate attempt to stop readiness requirements from restarting the round. Honestly this should just be 'false' by default, why the fuck would you want the random preset selection to shit itself?

jUsT hAvE a BiGgEr PoP aStRo :|