### PR TITLE
Toggle Hardsuit Helmets/Coat Hoods over existing headgear

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -94,8 +94,10 @@
   id: ClothingOuterStorageToggleableBase
   components:
   - type: ToggleableClothing # Goobstation - Modsuits change
-    clothingPrototypes: 
+    clothingPrototypes:
       head: ClothingHeadHatHoodWinterDefault
+    replaceCurrentClothing: true # ShibaStation - Wear hoods/hardsuit helmets without taking off your head gear first.
+    blockUnequipWhenAttached: true # ShibaStation - Janky workaround for removing an outerwear with part deployed yoinking your head gear (it's still there it's just IN the outerwear)
   - type: UserInterface
     interfaces:
       enum.ToggleClothingUiKey.Key:
@@ -133,6 +135,8 @@
         Heat: 0.90
         Radiation: 0.25
   - type: ToggleableClothing
+    replaceCurrentClothing: true # ShibaStation - Wear hoods/hardsuit helmets without taking off your head gear first.
+    blockUnequipWhenAttached: true # ShibaStation - Janky workaround for removing an outerwear with part deployed yoinking your head gear (it's still there it's just IN the outerwear)
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:Container {}
@@ -186,8 +190,10 @@
   abstract: True
   components:
   - type: ToggleableClothing # Goobstation - Modsuits change
-    clothingPrototypes: 
+    clothingPrototypes:
       head: ClothingHeadHatHoodWinterDefault
+    replaceCurrentClothing: true # ShibaStation - Wear hoods/hardsuit helmets without taking off your head gear first.
+    blockUnequipWhenAttached: true # ShibaStation - Janky workaround for removing an outerwear with part deployed yoinking your head gear (it's still there it's just IN the outerwear)
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:Container {}

--- a/Resources/Prototypes/_ShibaStation/Entities/Clothing/Back/modsuit.yml
+++ b/Resources/Prototypes/_ShibaStation/Entities/Clothing/Back/modsuit.yml
@@ -74,7 +74,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellMicroreactor
+        startingItem: PowerCellAntiqueProto
         whitelist:
           components:
             - PowerCell

--- a/Resources/Prototypes/_ShibaStation/Entities/Clothing/Head/modsuit.yml
+++ b/Resources/Prototypes/_ShibaStation/Entities/Clothing/Head/modsuit.yml
@@ -86,4 +86,6 @@
     autoRecharge: true
     autoRechargeRate: 2
   - type: ThermalVision
+    isEquipment: true
   - type: NightVision
+    isEquipment: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the `replaceCurrentClothing` and `blockUnequipWhenAttached` parameters to the `ToggleableClothing` component on the hardsuit and coat clothing bases.

Also fixes the admeme modsuit helmet not having NVG or thermal vision anymore after the MouseVGs fix.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Having to remove a small hair flower to pull up your hood or toggle your hardsuit is DUMB and this is really just a nice QoL change.

Replaced clothing naturally loses its worn benefits, which is the same as removing it, which you would've HAD to have done before. The only real balance change here is that you no longer have to potentially lose your headgear by discarding it on the floor or lose inventory space by stowing it. But I mean... c'mawn...

To account for a "not really bug but confusing symptom", you must have all toggled parts _off_ to remove the piece, but the game notifies you of this anyway and to be honest I don't think it's too unreasonable to assume you'd pull your hood down FIRST before removing your coat or disengage a hardsuit helmet before slipping out of it. The QoL benefit outweighs the 'cons' of this change imo. Cope.

## Technical details
<!-- Summary of code changes for easier review. -->
I already said what I did in the top section, just look at the commits. It's like six lines.
