### PR TITLE
Adds 'Inside Voice' Component

### DIFF
--- a/Content.Server/_ShibaStation/Speech/Components/InsideVoiceComponent.cs
+++ b/Content.Server/_ShibaStation/Speech/Components/InsideVoiceComponent.cs
@@ -3,6 +3,6 @@ using Robust.Shared.GameObjects;
 namespace Content.Server._ShibaStation.Speech.Components;
 
 [RegisterComponent]
-public sealed class InsideVoiceComponent : Component
+public sealed partial class InsideVoiceComponent : Component
 {
 }

--- a/Content.Server/_ShibaStation/Speech/Components/InsideVoiceComponent.cs
+++ b/Content.Server/_ShibaStation/Speech/Components/InsideVoiceComponent.cs
@@ -1,0 +1,8 @@
+using Robust.Shared.GameObjects;
+
+namespace Content.Server._ShibaStation.Speech.Components;
+
+[RegisterComponent]
+public sealed class InsideVoiceComponent : Component
+{
+}

--- a/Content.Server/_ShibaStation/Speech/EntitySystems/InsideVoiceSystem.cs
+++ b/Content.Server/_ShibaStation/Speech/EntitySystems/InsideVoiceSystem.cs
@@ -1,0 +1,100 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Linq;
+using Content.Server._ShibaStation.Speech.Components;
+using Content.Server.Speech;
+using Robust.Shared.Random;
+using Robust.Shared.IoC;
+
+namespace Content.Server._ShibaStation.Speech.EntitySystems;
+
+public sealed class InsideVoiceSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    private static readonly Regex WordSplitRegex = new(@"\b\w+\b", RegexOptions.Compiled);
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<InsideVoiceComponent, AccentGetEvent>(OnAccent);
+    }
+
+    private void OnAccent(EntityUid uid, InsideVoiceComponent component, AccentGetEvent args)
+    {
+        args.Message = Accentuate(args.Message);
+    }
+
+    private string Accentuate(string message)
+    {
+        var words = WordSplitRegex.Matches(message).Cast<Match>().ToList();
+        var consecutiveUppercaseCount = 0;
+        var needsReformatting = false;
+
+        // First pass: check if we need to reformat
+        foreach (var match in words)
+        {
+            var word = match.Value;
+
+            // Skip single-letter words and "I"
+            if (word.Length <= 1 || word == "I")
+                continue;
+
+            if (word.ToUpper() == word)
+                consecutiveUppercaseCount++;
+            else
+                consecutiveUppercaseCount = 0;
+
+            if (consecutiveUppercaseCount >= 2)
+            {
+                needsReformatting = true;
+                break;
+            }
+        }
+
+        if (!needsReformatting)
+            return message;
+
+        // Second pass: reformat the text
+        var result = new StringBuilder();
+        var lastIndex = 0;
+        var startOfSentence = true;
+
+        foreach (Match match in WordSplitRegex.Matches(message))
+        {
+            // Add any non-word characters before this word
+            result.Append(message.Substring(lastIndex, match.Index - lastIndex));
+
+            var word = match.Value;
+
+            // Special case for "I"
+            if (word == "I" || word.Length <= 1)
+            {
+                result.Append(word);
+            }
+            else
+            {
+                // Capitalize first letter if it's start of sentence, lowercase the rest
+                var formattedWord = startOfSentence
+                    ? char.ToUpper(word[0]) + word.Substring(1).ToLower()
+                    : word.ToLower();
+
+                result.Append(formattedWord);
+            }
+
+            lastIndex = match.Index + match.Length;
+
+            // Check if the next character starts a new sentence
+            if (lastIndex < message.Length)
+            {
+                var nextChar = message[lastIndex];
+                startOfSentence = nextChar == '.' || nextChar == '!' || nextChar == '?';
+            }
+        }
+
+        // Add any remaining text after the last word
+        result.Append(message.Substring(lastIndex));
+
+        return result.ToString();
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the `InsideVoice` component that forces all caps speak into proper case formatted text.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
All Capsers need to calm the fuck down and this is an admin applicable component that should ideally never need to be broken out but is there to deal with it.

It only kicks in if more than two words in a sentence are all caps, so you can still emphasise parts of speech. It's also only applied manually by an admin so for the occasional all caps post it also won't apply.

## Technical details
<!-- Summary of code changes for easier review. -->
see diffs (why does this section exist?)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Note; the perspective change is because this character has the illeism trait, just ignore that part, look how the big letter become smol.
![SS14 Loader_9jLGhhk5Uo](https://github.com/user-attachments/assets/09dfb8b1-1b89-4aad-a706-838b406f2632)
