### PR TITLE
Upgrade JRPACMAN to regular PACMAN on Mining Shuttle

### DIFF
--- a/Resources/Maps/Shuttles/mining.yml
+++ b/Resources/Maps/Shuttles/mining.yml
@@ -1016,13 +1016,23 @@ entities:
     - type: Transform
       pos: -1.4453101,4.467156
       parent: 181
-- proto: PortableGeneratorJrPacman
+- proto: PortableGeneratorPacman
   entities:
-  - uid: 58
+  - uid: 40
     components:
     - type: Transform
+      anchored: True
       pos: -1.5,-6.5
       parent: 181
+    - type: MaterialStorage
+      storage:
+        Plasma: 3000
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      bodyType: Static
+    - type: InsertingMaterialStorage
+      endTime: 0
 - proto: PoweredSmallLight
   entities:
   - uid: 138
@@ -1086,6 +1096,13 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-6.5
+      parent: 181
+- proto: SheetPlasma
+  entities:
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
       parent: 181
 - proto: SignalButtonExt1
   entities:
@@ -1302,13 +1319,6 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-5.5
-      parent: 181
-- proto: WeldingFuelTankFull
-  entities:
-  - uid: 40
-    components:
-    - type: Transform
-      pos: -2.5,-5.5
       parent: 181
 - proto: Window
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Replaced the JRPACMAN with a regular PACMAN, anchored it, prefuelled it and also added a second stack of Plasma.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Turns out I'm dumb and JRPACMAN generators are only for LV cable connections. While that still would've worked I didn't want to link two APCs together. The regular PACMAN can charge the shuttle's SMES now.
