### PR TITLE
Emote/Subtle Emote Tweaks

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -225,7 +225,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         // Was there an emote in the message? If so, send it.
         if (player != null && emoteStr != message && emoteStr != null)
         {
-            SendEntityEmote(source, emoteStr, range, nameOverride, ignoreActionBlocker);
+            SendEntityEmote(source, emoteStr, range, nameOverride, hideLog, true, ignoreActionBlocker);
         }
 
         // This can happen if the entire string is sanitized out.
@@ -589,6 +589,14 @@ public sealed partial class ChatSystem : SharedChatSystem
         var ent = Identity.Entity(source, EntityManager);
         string name = FormattedMessage.EscapeText(nameOverride ?? Name(ent));
 
+        // Force first word of action to lowercase
+        var words = action.Split(new[] { ' ' }, 2);
+        if (words.Length > 0)
+        {
+            words[0] = words[0].ToLowerInvariant();
+            action = string.Join(" ", words);
+        }
+
         // Emotes use Identity.Name, since it doesn't actually involve your voice at all.
         var wrappedMessage = Loc.GetString("chat-manager-entity-me-wrap-message",
             ("entityName", name),
@@ -621,6 +629,14 @@ public sealed partial class ChatSystem : SharedChatSystem
         // get the entity's apparent name (if no override provided).
         var ent = Identity.Entity(source, EntityManager);
         string name = FormattedMessage.EscapeText(nameOverride ?? Name(ent));
+
+        // Force first word of action to lowercase
+        var words = action.Split(new[] { ' ' }, 2);
+        if (words.Length > 0)
+        {
+            words[0] = words[0].ToLowerInvariant();
+            action = string.Join(" ", words);
+        }
 
         // Emotes use Identity.Name, since it doesn't actually involve your voice at all.
         var wrappedMessage = Loc.GetString("chat-manager-entity-subtle-wrap-message",

--- a/Resources/Locale/en-US/_Floofstation/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/_Floofstation/chat/managers/chat-manager.ftl
@@ -1,4 +1,4 @@
 chat-manager-entity-subtle-wrap-message = [italic]{ PROPER($entity) ->
-    *[false] the {$entityName} subtly {$message}[/italic]
-     [true] {$entityName} subtly {$message}[/italic]
+    *[false] * the {$entityName} {$message}[/italic]
+     [true] * {$entityName} {$message}[/italic]
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Subtle Emotes now display with an asterisk prefix and no longer say 'subtly'.
Both Emotes and Subtle Emotes now ensure the first word after the chat trigger is lower case for grammatical consistency.

Old Subtle Emotes:
`Urist subtly does a thing.`
New Subtle Emotes:
`* Urist does a thing.`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Having to work around the adverb 'subtly' actually limits how you can write your emotes, as an RP nerd.
Lowercasing the first word is also just handy for grammatical consistency and is merely just a petty tweak.
