### PR TITLE
Revert "[PORT] Vent Critters Rework from Delta-V (#1450)"

### DIFF
--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -1,6 +1,5 @@
 ﻿using Content.Server.StationEvents.Events;
 using Content.Shared.Storage;
-using Robust.Shared.Map; // DeltaV
 
 namespace Content.Server.StationEvents.Components;
 
@@ -15,28 +14,4 @@ public sealed partial class VentCrittersRuleComponent : Component
     /// </summary>
     [DataField("specialEntries")]
     public List<EntitySpawnEntry> SpecialEntries = new();
-
-    /// <summary>
-    /// DeltaV: The location of the vent that got picked.
-    /// </summary>
-    [ViewVariables]
-    public EntityCoordinates? Location;
-
-    /// <summary>
-    /// DeltaV: Base minimum number of critters to spawn.
-    /// </summary>
-    [DataField]
-    public int Min = 2;
-
-    /// <summary>
-    /// DeltaV: Base maximum number of critters to spawn.
-    /// </summary>
-    [DataField]
-    public int Max = 3;
-
-    /// <summary>
-    /// DeltaV: Min and max get multiplied by the player count then divided by this.
-    /// </summary>
-    [DataField]
-    public int PlayerRatio = 25;
 }

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -1,23 +1,12 @@
-using Content.Server.Antag;
-using Content.Server.GameTicking.Rules.Components;
-using Content.Server.Pinpointer;
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Station.Components;
 using Content.Shared.Storage;
 using Robust.Shared.Map;
-using Robust.Shared.Player;
 using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
 
-/// <summary>
-/// DeltaV: Reworked vent critters to spawn a number of mobs at a single telegraphed location.
-/// This gives players time to run away and let sec do their job.
-/// </summary>
-/// <remarks>
-/// This entire file is rewritten, ignore upstream changes.
-/// </remarks>
 public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleComponent>
 {
     /*
@@ -25,75 +14,45 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
      * USE THE PROTOTYPE.
      */
 
-    [Dependency] private readonly AntagSelectionSystem _antag = default!;
-    [Dependency] private readonly ISharedPlayerManager _player = default!;
-    [Dependency] private readonly NavMapSystem _navMap = default!;
-    [Dependency] private readonly SharedTransformSystem _transform = default!;
-
-    private List<EntityCoordinates> _locations = new();
-
-    protected override void Added(EntityUid uid, VentCrittersRuleComponent comp, GameRuleComponent gameRule, GameRuleAddedEvent args)
+    protected override void Started(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
-        PickLocation(comp);
-        if (comp.Location is not {} coords)
-        {
-            ForceEndSelf(uid, gameRule);
-            return;
-        }
+        base.Started(uid, component, gameRule, args);
 
-        var mapCoords = _transform.ToMapCoordinates(coords);
-        if (!_navMap.TryGetNearestBeacon(mapCoords, out var beacon, out _))
-            return;
-
-        var nearest = beacon?.Comp?.Text!;
-        Comp<StationEventComponent>(uid).StartAnnouncement = Loc.GetString("station-event-vent-creatures-start-announcement-deltav", ("location", nearest));
-
-        base.Added(uid, comp, gameRule, args);
-    }
-
-    protected override void Ended(EntityUid uid, VentCrittersRuleComponent comp, GameRuleComponent gameRule, GameRuleEndedEvent args)
-    {
-        base.Ended(uid, comp, gameRule, args);
-
-        if (comp.Location is not {} coords)
-            return;
-
-        var players = _antag.GetTotalPlayerCount(_player.Sessions);
-        var min = comp.Min * players / comp.PlayerRatio;
-        var max = comp.Max * players / comp.PlayerRatio;
-        var count = Math.Max(RobustRandom.Next(min, max), 1);
-        for (int i = 0; i < count; i++)
-        {
-            foreach (var spawn in EntitySpawnCollection.GetSpawns(comp.Entries, RobustRandom))
-            {
-                Spawn(spawn, coords);
-            }
-        }
-
-        if (comp.SpecialEntries.Count == 0)
-            return;
-
-        // guaranteed spawn
-        var specialEntry = RobustRandom.Pick(comp.SpecialEntries);
-        Spawn(specialEntry.PrototypeId, coords);
-    }
-
-    private void PickLocation(VentCrittersRuleComponent comp)
-    {
         if (!TryGetRandomStation(out var station))
+        {
             return;
+        }
 
         var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
-        _locations.Clear();
-        while (locations.MoveNext(out var uid, out _, out var transform))
+        var validLocations = new List<EntityCoordinates>();
+        while (locations.MoveNext(out _, out _, out var transform))
         {
             if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station)
             {
-                _locations.Add(transform.Coordinates);
+                validLocations.Add(transform.Coordinates);
+                foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
+                {
+                    Spawn(spawn, transform.Coordinates);
+                }
             }
         }
 
-        if (_locations.Count > 0)
-            comp.Location = RobustRandom.Pick(_locations);
+        if (component.SpecialEntries.Count == 0 || validLocations.Count == 0)
+        {
+            return;
+        }
+
+        // guaranteed spawn
+        var specialEntry = RobustRandom.Pick(component.SpecialEntries);
+        var specialSpawn = RobustRandom.Pick(validLocations);
+        Spawn(specialEntry.PrototypeId, specialSpawn);
+
+        foreach (var location in validLocations)
+        {
+            foreach (var spawn in EntitySpawnCollection.GetSpawns(component.SpecialEntries, RobustRandom))
+            {
+                Spawn(spawn, location);
+            }
+        }
     }
 }

--- a/Resources/Locale/en-US/deltav/station-events/events/vent-critters.ftl
+++ b/Resources/Locale/en-US/deltav/station-events/events/vent-critters.ftl
@@ -1,1 +1,0 @@
-﻿station-event-vent-creatures-start-announcement-deltav = Attention. A large influx of unknown life forms has been detected in ventilation systems near {$location}. All personnel must vacate the area immediately.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -370,8 +370,8 @@
       path: /Audio/_ShibaStation/Announcements/vent-3-hostile.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
-    duration: 30 # DeltaV: was 60, used as a delay now
+    weight: 0.5 # GoobStation: was 5, vent critters bad
+    duration: 60
   - type: VentCrittersRule
     entries:
     - id: MobAdultSlimesBlueAngry
@@ -391,8 +391,8 @@
       path: /Audio/_ShibaStation/Announcements/vent-3-hostile.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
-    duration: 30 # DeltaV: was 60, used as a delay now
+    weight: 2 # GoobStation: was 5, critters because bad
+    duration: 60
   - type: VentCrittersRule
     entries:
     - id: MobPurpleSnake
@@ -412,8 +412,8 @@
       path: /Audio/_ShibaStation/Announcements/vent-3-hostile.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
-    duration: 30 # DeltaV: was 60, used as a delay now
+    weight: 1 # GoobStation: was 1, vent critters bad
+    duration: 60
   - type: VentCrittersRule
     entries:
     - id: MobGiantSpiderAngry
@@ -426,13 +426,12 @@
   - type: StationEvent
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
-      path: /Audio/Announcements/attention.ogg
-    earliestStart: 45 # DeltaV - was 20
-    minimumPlayers: 30 # DeltaV - was 20
-    weight: 1 # DeltaV - was 1.5
-    duration: 30 # DeltaV: was 60, used as a delay now
+      path: /Audio/Announcements/aliens.ogg
+    earliestStart: 20
+    minimumPlayers: 20
+    weight: 0.5 # GoobStation: was 1.5, vent critters bad
+    duration: 60
   - type: VentCrittersRule
-    playerRatio: 35 # DeltaV: Clown spiders are very robust
     entries:
     - id: MobClownSpider
       prob: 0.05

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -28,7 +28,7 @@
       path: /Audio/_ShibaStation/Announcements/vent-1-safe.ogg
     earliestStart: 15
     weight: 6
-    duration: 30 # DeltaV: was 50, used as a delay now
+    duration: 50
   - type: VentCrittersRule
     entries:
     - id: MobMouse
@@ -51,7 +51,7 @@
       path: /Audio/_ShibaStation/Announcements/vent-5-danger.ogg
     earliestStart: 15
     weight: 6
-    duration: 30 # DeltaV: was 50, used as a delay now
+    duration: 50
     minimumPlayers: 30 # Hopefully this is enough for the Rat King's potential Army (it was not, raised from 15 -> 30)
   - type: VentCrittersRule
     entries:
@@ -78,7 +78,7 @@
     startAudio:
       path: /Audio/_ShibaStation/Announcements/vent-1-safe.ogg
     weight: 6
-    duration: 30 # DeltaV: was 50, used as a delay now
+    duration: 50
   - type: VentCrittersRule
     entries:
     - id: MobCockroach
@@ -97,7 +97,7 @@
     startAudio:
       path: /Audio/_ShibaStation/Announcements/vent-1-safe.ogg
     weight: 6
-    duration: 30 # DeltaV: was 50, used as a delay now
+    duration: 50
   - type: VentCrittersRule
     entries:
     - id: MobSnail
@@ -117,7 +117,7 @@
       path: /Audio/_ShibaStation/Announcements/vent-1-safe.ogg
     earliestStart: 15
     weight: 6
-    duration: 30 # DeltaV: was 50, used as a delay now
+    duration: 50
     minimumPlayers: 30
   - type: VentCrittersRule
     entries:


### PR DESCRIPTION
This reverts commit 2fff7eceff9dc6c4cbc540e6549199331b262c7e.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
see title dummy

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We'd already compensated for the issue of critter spam by reducing the event types down into two grouped events, one for non-hostiles and one for hostiles, where the selection of critters is pooled and varied instead of separate events for each critter type.

This change, while nice to have the callout of the location, effectively broke our spawns by rarely if ever actually spawning anything. This reverts it back to how it was, bringing back mice for non-humans to binge on and varied waves of monsters for the crew to defend against.