### PR TITLE
RemoveGridsByValue Command

### DIFF
--- a/Content.Server/_ShibaStation/Commands/RemoveGridsByValue.cs
+++ b/Content.Server/_ShibaStation/Commands/RemoveGridsByValue.cs
@@ -1,0 +1,81 @@
+using Content.Server.Administration;
+using Content.Server.Cargo.Systems;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.IoC;
+using Robust.Shared.GameObjects;
+
+namespace Content.Server._ShibaStation.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class RemoveGridsByValueCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    public string Command => "rmgridsbyvalue";
+    public string Description => "Removes all grids with a value less than or equal to the specified threshold (default: 0).";
+    public string Help => "rmgridsbyvalue [maxValue]";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var maxValue = 0.0;
+        if (args.Length > 0 && !double.TryParse(args[0], out maxValue))
+        {
+            shell.WriteError("Invalid maxValue argument. Please provide a valid number.");
+            return;
+        }
+
+        var pricingSystem = _entManager.System<PricingSystem>();
+        var mapManager = IoCManager.Resolve<IMapManager>();
+        var player = shell.Player;
+
+        // Get the player's current map if they're in-game
+        MapId targetMap;
+        if (player?.AttachedEntity != null)
+        {
+            var transform = _entManager.GetComponent<TransformComponent>(player.AttachedEntity.Value);
+            targetMap = transform.MapID;
+        }
+        else if (args.Length > 1 && int.TryParse(args[1], out var mapId))
+        {
+            targetMap = new MapId(mapId);
+        }
+        else
+        {
+            shell.WriteError("No valid map found. Either use this command in-game or specify a map ID.");
+            return;
+        }
+
+        if (!mapManager.MapExists(targetMap))
+        {
+            shell.WriteError($"Map {targetMap} does not exist.");
+            return;
+        }
+
+        var gridsToDelete = new List<EntityUid>();
+        var gridsChecked = 0;
+
+        // Find all grids on the map
+        foreach (var grid in mapManager.GetAllGrids(targetMap))
+        {
+            if (!_entManager.HasComponent<MapGridComponent>(grid.Owner))
+                continue;
+
+            gridsChecked++;
+            var gridValue = pricingSystem.AppraiseGrid(grid.Owner);
+
+            if (gridValue <= maxValue)
+                gridsToDelete.Add(grid.Owner);
+        }
+
+        // Delete the identified grids
+        foreach (var gridUid in gridsToDelete)
+        {
+            _entManager.DeleteEntity(gridUid);
+        }
+
+        shell.WriteLine($"Checked {gridsChecked} grids. Removed {gridsToDelete.Count} grids with value <= {maxValue}.");
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the `RemoveGridsByValue` command, `rmgridsbyvalue`, to help automate the removal of grids that have no or up to a specified value in order to account for server load by using WorldGen (asteroids and debris chunks).

The command is available to users with `admin` permissions.

Run by itself, `rmgridsbyvalue` will identify and delete all grids on a map that have a value of 0.
Additionally, `rmgridsbyvalue [int]` will target grids of a value up to the `int`, useful if you also want to include those small chunks from the VGroid that are just iron rock and no ores of value.

As a happy virtue of how the `AppraiseGrid` function works, there's no risk of deleting a freshly mined asteroid from underneath a salvager's feet while they're still on the grid, as the salvager themselves are included in the calculation.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As a server that uses the WorldGen to generate asteroid chunks and debris for salvagers to work on in the early game before going off to die on the VGroid, an issue that __can__ occur is that on a long shift or with a particularly effective salvage crew (rare as that is), there will be *a lot* of loaded grids on a map that after a while can start to impact server performance.

This simple command makes identifying and deleting literally worthless grids a breeze and when used at the right time can instantly see the server FPS increase by 100+, solving server-related lag issues.

The function is currently __not__ automated, as a side effect of how WorldGen works, is that it will also indiscriminately target grids that may have generated their floors but not their content - as in, asteroids that an entity has been close enough to cause to spawn but not __closer__ enough for the rock and ores to spawn. This means it'll also delete potentially unmined asteroids. 

It should be considered more as the 'nuclear option' if grid-related issues are plaguing server performance.