### PR TITLE
Added 'Cycling' Mode to Air Alarms

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
@@ -58,6 +58,8 @@ public sealed partial class AirAlarmWindow : FancyWindow
                 AirAlarmMode.Fill => "air-alarm-ui-mode-fill",
                 AirAlarmMode.Panic => "air-alarm-ui-mode-panic",
                 AirAlarmMode.None => "air-alarm-ui-mode-none",
+                AirAlarmMode.Cycling => "air-alarm-ui-mode-cycling",
+                AirAlarmMode.WideCycling => "air-alarm-ui-mode-wide-cycling",
                 _ => "error",
             };
             _modes.AddItem(Loc.GetString(text));

--- a/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
+++ b/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
@@ -16,6 +16,8 @@ public enum AirAlarmMode
     WideFiltering,
     Fill,
     Panic,
+    Cycling,
+    WideCycling,
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
@@ -34,6 +34,8 @@ air-alarm-ui-mode-wide-filtering = Filtering (wide)
 air-alarm-ui-mode-fill = Fill
 air-alarm-ui-mode-panic = Panic
 air-alarm-ui-mode-none = None
+air-alarm-ui-mode-cycling = Cycling
+air-alarm-ui-mode-wide-cycling = Cycling (wide)
 
 ## Widgets
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added 'Cycling' and 'Cycling (Wide)' to the Air Alarms; modes that keep air vents distributing air but scrubbers into siphoning mode - effectively creating a complete circulation of all gasses (depending on the number of vents to scrubbers).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With the lowered pressure lockout on vents, this is a real simple way to quickly regulate temperature in areas that may have been affected due to frezon and nitrium leaks. Simply set the system to 'Cycling' and the scrubbers will siphon out the hot/cold gasses and the vents will pump in 20C from the distro.

This isn't a silver bullet but should at least remove some tedium from atmos having to 'pump and dump' manually and in some circumstances it can be more effective than space heaters alone. It also helps account for pressure changes due to temperature when using space heaters, so less instances of space wind throwing people across rooms.

## Technical details
<!-- Summary of code changes for easier review. -->
Added two new modes to the air alarm system that control the air vents and air scrubbers.
Just look at the diffs, forehead.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![SS14 Loader_gbtG3BRfPJ](https://github.com/user-attachments/assets/2004c09a-d224-4921-8c4d-b2fab095cdef)

