### PR TITLE
Add air scrubbers to the Cargo and Mining shuttles

### DIFF
--- a/Resources/Maps/Shuttles/cargo.yml
+++ b/Resources/Maps/Shuttles/cargo.yml
@@ -18,7 +18,7 @@ entities:
       name: Cargo Shuttle
     - type: Transform
       pos: 2.2710133,-2.4148211
-
+      parent: invalid
     - type: MapGrid
       chunks:
         -1,0:
@@ -145,6 +145,10 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         chunkSize: 4
     - type: OccluderTree
     - type: Shuttle
@@ -154,6 +158,18 @@ entities:
     - type: GravityShake
       shakeTimes: 10
     - type: GasTileOverlay
+- proto: AirAlarm
+  entities:
+  - uid: 194
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 173
+    - type: DeviceList
+      devices:
+      - 86
+      - 84
 - proto: AirCanister
   entities:
   - uid: 172
@@ -443,28 +459,23 @@ entities:
       parent: 173
 - proto: CableHV
   entities:
-  - uid: 80
+  - uid: 64
     components:
     - type: Transform
-      pos: -1.5,-2.5
+      pos: -2.5,-1.5
       parent: 173
   - uid: 81
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 173
-  - uid: 86
+  - uid: 82
     components:
     - type: Transform
-      pos: -2.5,-3.5
+      pos: -1.5,-1.5
       parent: 173
 - proto: CableMV
   entities:
-  - uid: 87
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
-      parent: 173
   - uid: 88
     components:
     - type: Transform
@@ -527,14 +538,20 @@ entities:
       parent: 173
 - proto: CableTerminal
   entities:
-  - uid: 82
+  - uid: 80
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,-3.5
+      pos: -2.5,-2.5
       parent: 173
 - proto: CargoPallet
   entities:
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 173
   - uid: 151
     components:
     - type: Transform
@@ -726,27 +743,35 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 173
-- proto: GasPipeBend
+- proto: GasPassiveVent
   entities:
-  - uid: 134
+  - uid: 191
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-1.5
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 173
+- proto: GasPipeBend
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,2.5
       parent: 173
 - proto: GasPipeStraight
   entities:
+  - uid: 87
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-1.5
+      parent: 173
   - uid: 136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,0.5
-      parent: 173
-  - uid: 137
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,1.5
       parent: 173
   - uid: 140
     components:
@@ -754,34 +779,79 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,-0.5
       parent: 173
-- proto: GasPort
-  entities:
-  - uid: 135
+  - uid: 188
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 173
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 173
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 173
+  - uid: 192
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-2.5
+      parent: 173
+  - uid: 193
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 173
+- proto: GasPort
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -3.5,-1.5
       parent: 173
 - proto: GasVentPump
   entities:
-  - uid: 138
+  - uid: 84
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 173
-- proto: GeneratorBasic15kW
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 194
+- proto: GasVentScrubber
   entities:
-  - uid: 83
+  - uid: 86
     components:
     - type: Transform
-      pos: -2.5,-3.5
+      pos: -2.5,1.5
+      parent: 173
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 194
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
       parent: 173
 - proto: GravityGeneratorMini
   entities:
-  - uid: 146
+  - uid: 138
     components:
     - type: Transform
-      pos: -1.5,-1.5
+      pos: -1.5,-2.5
       parent: 173
 - proto: Grille
   entities:
@@ -951,17 +1021,17 @@ entities:
       parent: 173
 - proto: SMESBasic
   entities:
-  - uid: 84
+  - uid: 83
     components:
     - type: Transform
-      pos: -2.5,-2.5
+      pos: -2.5,-1.5
       parent: 173
 - proto: SubstationBasic
   entities:
-  - uid: 85
+  - uid: 134
     components:
     - type: Transform
-      pos: -1.5,-2.5
+      pos: -1.5,-1.5
       parent: 173
 - proto: TableReinforced
   entities:
@@ -1238,11 +1308,6 @@ entities:
     - type: Transform
       pos: -3.5,-4.5
       parent: 173
-  - uid: 64
-    components:
-    - type: Transform
-      pos: -2.5,-4.5
-      parent: 173
   - uid: 65
     components:
     - type: Transform
@@ -1258,6 +1323,12 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-3.5
+      parent: 173
+  - uid: 137
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
       parent: 173
 - proto: WindoorCargoLocked
   entities:

--- a/Resources/Maps/Shuttles/mining.yml
+++ b/Resources/Maps/Shuttles/mining.yml
@@ -34,7 +34,7 @@ entities:
           version: 6
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAACWQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAACWQAAAAACWQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAACWQAAAAADWQAAAAACWQAAAAADWQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAADWQAAAAACWQAAAAAAWQAAAAADWQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAWQAAAAACWQAAAAABWQAAAAADWQAAAAABWQAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAACWQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAACWQAAAAACWQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAACWQAAAAADWQAAAAACWQAAAAADWQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAADWQAAAAACWQAAAAAAWQAAAAADWQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAWQAAAAACWQAAAAABWQAAAAADWQAAAAABWQAAAAAA
           version: 6
     - type: Broadphase
     - type: Physics
@@ -520,6 +520,18 @@ entities:
       shakeTimes: 10
     - type: GasTileOverlay
     - type: GridPathfinding
+- proto: AirAlarm
+  entities:
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 181
+    - type: DeviceList
+      devices:
+      - 116
+      - 134
+      - 26
 - proto: AirlockCargoGlass
   entities:
   - uid: 29
@@ -630,11 +642,6 @@ entities:
       parent: 181
 - proto: CableApcExtension
   entities:
-  - uid: 1
-    components:
-    - type: Transform
-      pos: -3.5,-6.5
-      parent: 181
   - uid: 3
     components:
     - type: Transform
@@ -770,22 +777,12 @@ entities:
   - uid: 6
     components:
     - type: Transform
-      pos: -3.5,-6.5
-      parent: 181
-  - uid: 59
-    components:
-    - type: Transform
-      pos: -1.5,-6.5
+      pos: -2.5,-5.5
       parent: 181
   - uid: 74
     components:
     - type: Transform
       pos: -3.5,-5.5
-      parent: 181
-  - uid: 75
-    components:
-    - type: Transform
-      pos: -2.5,-6.5
       parent: 181
   - uid: 76
     components:
@@ -876,11 +873,11 @@ entities:
       parent: 181
 - proto: CableTerminal
   entities:
-  - uid: 77
+  - uid: 33
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,-6.5
+      pos: -1.5,-5.5
       parent: 181
 - proto: Catwalk
   entities:
@@ -888,6 +885,12 @@ entities:
     components:
     - type: Transform
       pos: -2.5,-5.5
+      parent: 181
+  - uid: 50
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-7.5
       parent: 181
 - proto: Chair
   entities:
@@ -912,6 +915,80 @@ entities:
     - type: Transform
       pos: -2.5,6.5
       parent: 181
+- proto: GasPassiveVent
+  entities:
+  - uid: 137
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-7.5
+      parent: 181
+- proto: GasPipeBend
+  entities:
+  - uid: 157
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 181
+- proto: GasPipeStraight
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-5.5
+      parent: 181
+  - uid: 75
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-6.5
+      parent: 181
+  - uid: 139
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 181
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 181
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-1.5
+      parent: 181
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-0.5
+      parent: 181
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 181
+  - uid: 152
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,1.5
+      parent: 181
+- proto: GasPipeTJunction
+  entities:
+  - uid: 155
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 181
 - proto: GasPort
   entities:
   - uid: 25
@@ -928,12 +1005,41 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -3.5,-4.5
       parent: 181
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 158
+- proto: GasVentScrubber
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 181
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 158
+  - uid: 134
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 181
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 158
 - proto: GravityGeneratorMini
   entities:
   - uid: 39
     components:
     - type: Transform
-      pos: -3.5,-6.5
+      pos: -3.5,-5.5
       parent: 181
 - proto: Grille
   entities:
@@ -942,20 +1048,10 @@ entities:
     - type: Transform
       pos: 0.5,-3.5
       parent: 181
-  - uid: 33
-    components:
-    - type: Transform
-      pos: -2.5,-7.5
-      parent: 181
   - uid: 34
     components:
     - type: Transform
       pos: 0.5,-1.5
-      parent: 181
-  - uid: 50
-    components:
-    - type: Transform
-      pos: -1.5,-7.5
       parent: 181
   - uid: 56
     components:
@@ -966,6 +1062,12 @@ entities:
     components:
     - type: Transform
       pos: -0.5,5.5
+      parent: 181
+  - uid: 98
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-6.5
       parent: 181
   - uid: 136
     components:
@@ -1018,11 +1120,11 @@ entities:
       parent: 181
 - proto: PortableGeneratorPacman
   entities:
-  - uid: 40
+  - uid: 67
     components:
     - type: Transform
       anchored: True
-      pos: -1.5,-6.5
+      pos: -1.5,-5.5
       parent: 181
     - type: MaterialStorage
       storage:
@@ -1121,10 +1223,10 @@ entities:
         - Pressed: Toggle
 - proto: SMESBasic
   entities:
-  - uid: 24
+  - uid: 1
     components:
     - type: Transform
-      pos: -2.5,-6.5
+      pos: -2.5,-5.5
       parent: 181
 - proto: SubstationWallBasic
   entities:
@@ -1147,6 +1249,12 @@ entities:
     components:
     - type: Transform
       pos: 0.5,4.5
+      parent: 181
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-7.5
       parent: 181
   - uid: 115
     components:
@@ -1172,6 +1280,24 @@ entities:
     components:
     - type: Transform
       pos: -3.5,0.5
+      parent: 181
+  - uid: 59
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 181
+  - uid: 77
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 181
+  - uid: 79
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-6.5
       parent: 181
   - uid: 85
     components:
@@ -1202,6 +1328,12 @@ entities:
     components:
     - type: Transform
       pos: -6.5,1.5
+      parent: 181
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-7.5
       parent: 181
   - uid: 97
     components:
@@ -1238,11 +1370,6 @@ entities:
     - type: Transform
       pos: -0.5,-6.5
       parent: 181
-  - uid: 109
-    components:
-    - type: Transform
-      pos: -0.5,-7.5
-      parent: 181
   - uid: 110
     components:
     - type: Transform
@@ -1257,11 +1384,6 @@ entities:
     components:
     - type: Transform
       pos: -5.5,0.5
-      parent: 181
-  - uid: 116
-    components:
-    - type: Transform
-      pos: -4.5,-7.5
       parent: 181
   - uid: 117
     components:
@@ -1327,6 +1449,12 @@ entities:
     - type: Transform
       pos: 0.5,-1.5
       parent: 181
+  - uid: 24
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-6.5
+      parent: 181
   - uid: 36
     components:
     - type: Transform
@@ -1336,11 +1464,6 @@ entities:
     components:
     - type: Transform
       pos: -2.5,7.5
-      parent: 181
-  - uid: 79
-    components:
-    - type: Transform
-      pos: -1.5,-7.5
       parent: 181
   - uid: 81
     components:
@@ -1356,16 +1479,6 @@ entities:
     components:
     - type: Transform
       pos: -0.5,5.5
-      parent: 181
-  - uid: 96
-    components:
-    - type: Transform
-      pos: -3.5,-7.5
-      parent: 181
-  - uid: 98
-    components:
-    - type: Transform
-      pos: -2.5,-7.5
       parent: 181
   - uid: 102
     components:

--- a/Resources/Maps/Shuttles/mining.yml
+++ b/Resources/Maps/Shuttles/mining.yml
@@ -871,6 +871,16 @@ entities:
     - type: Transform
       pos: -1.5,-5.5
       parent: 181
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 181
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 181
 - proto: CableTerminal
   entities:
   - uid: 33
@@ -1134,7 +1144,6 @@ entities:
       linearDamping: 0
       bodyType: Static
     - type: InsertingMaterialStorage
-      endTime: 0
 - proto: PoweredSmallLight
   entities:
   - uid: 138


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Tiny adjustment to the shuttles to accommodate the addition of scrubbers venting to space, air alarms and a bonus upgrade to the salvage shuttle to give it space for four forward thrusters (if salvage ever even bother to fix up the shittle in the first place).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
lmao bz leak kill everyone :)

## Technical details
<!-- Summary of code changes for easier review. -->
it's mapping changes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![SS14 Loader_tWP36UTizU](https://github.com/user-attachments/assets/7635ed70-e238-4a02-9718-46104f4760eb)
![SS14 Loader_X4jXVw4jPQ](https://github.com/user-attachments/assets/2c46bab8-08d7-449e-af67-374b3ebf74d1)
