### PR TITLE
Adds --hidden argument to aghost command

### DIFF
--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
 using Content.Shared.Popups;
 using Robust.Shared.Serialization;
+using Robust.Shared.Maths;
 
 namespace Content.Shared.Ghost
 {
@@ -56,6 +57,15 @@ namespace Content.Shared.Ghost
         public void SetCanReturnToBody(GhostComponent component, bool value)
         {
             component.CanReturnToBody = value;
+        }
+
+        public void SetColor(EntityUid uid, Color value, GhostComponent? component = null)
+        {
+            if (!Resolve(uid, ref component))
+                return;
+
+            component.color = value;
+            Dirty(uid, component);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the `--hidden` or `-h` argument to the `aghost` command to enter an admin ghost/observer on a different visibility layer to be hidden from regular observers/ghosts - while still being visible to other admin ghosts.

Additionally, for the benefit of the admin themselves and other admins, their ghost turns light blue to make it apparent they are in 'extra ghosty' mode. Otherwise they have the same actions, abilities and loadout.

Basically integrated a script that was shared by Crazybrain, so I take no credit for the idea of making extra ghosty aghosts - just making it more convenient for admins to do!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Sometimes admins need to be extra hidden, even from other ghosts. 👀 

## Technical details
<!-- Summary of code changes for easier review. -->
Due to some weirdness trying to do this in the prototype direction, instead the aghost command now ensures that the EyeComponent has its VisiblityMask set to 7 and then also sets the VisiblityComponent layer to 4 if the `--hidden` argument is passed, making them hidden from regular observer ghosts (whose VisibilityMask can see up to 3).

Also added a method to set ghost colours to the SharedGhostComponent that is independent from RMC14's GhostColor component used as part of patreon perks. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![SS14 Loader_XLUewv0gSX](https://github.com/user-attachments/assets/1cb554a9-ecc0-4171-80b9-6f60c0d84df3)
spoogy blue ghost for extra spooginess
![SS14 Loader_Yjjsfa9zyO](https://github.com/user-attachments/assets/f88beb03-f1d0-444b-953c-419b8766b568)

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Because this touches the aghost command and sharedghostcomponent code direction, while this doesn't break anything right now - if this is ever changed by upstream in the future, then it's gonna likely cause a merge conflict. Such is life in FOSS.
