### PR TITLE
Custom Objectives Commands

### DIFF
--- a/Content.Server/_ShibaStation/Objectives/Commands/AddCustomObjectiveCommand.cs
+++ b/Content.Server/_ShibaStation/Objectives/Commands/AddCustomObjectiveCommand.cs
@@ -1,0 +1,84 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.Mind;
+using Content.Server._ShibaStation.Objectives.Systems;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+using Content.Shared.Objectives.Components;
+using Robust.Shared.Utility;
+
+namespace Content.Server._ShibaStation.Objectives.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class AddCustomObjectiveCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IPlayerManager _players = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+
+    public string Command => "customobjective";
+    public string Description => "Adds a custom objective to a player.";
+    public string Help => "customobjective <username> <issuer> <title> <text> [icon entity]\nExample: customobjective username \"Devious Inc\" \"Steal Towels\" \"Steal 5 towels from the station\" Towel";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length < 4)
+        {
+            shell.WriteError("Expected at least 4 arguments: <username> <issuer> <title> <text> [icon entity]");
+            return;
+        }
+
+        if (!_players.TryGetSessionByUsername(args[0], out var session))
+        {
+            shell.WriteError("Can't find the player.");
+            return;
+        }
+
+        var minds = _entityManager.System<SharedMindSystem>();
+        if (!minds.TryGetMind(session, out var mindId, out var mind))
+        {
+            shell.WriteError("Can't find the mind.");
+            return;
+        }
+
+        var issuer = args[1];
+        var title = args[2];
+        var text = args[3];
+
+        // Set the icon if provided
+        SpriteSpecifier? icon = null;
+        if (args.Length > 4)
+        {
+            var iconProto = args[4];
+            if (!_prototype.HasIndex<EntityPrototype>(iconProto))
+            {
+                shell.WriteError($"Invalid entity prototype: {iconProto}");
+                return;
+            }
+            icon = new SpriteSpecifier.EntityPrototype(iconProto);
+        }
+
+        var customSystem = _entityManager.System<CustomObjectiveSystem>();
+        var objective = customSystem.CreateCustomObjective(issuer, title, text, icon);
+
+        minds.AddObjective(mindId, mind, objective);
+        shell.WriteLine($"Added custom objective '{title}' to {args[0]} under issuer '{issuer}'");
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+            return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), "<username>");
+        if (args.Length == 2)
+            return CompletionResult.FromHint("<issuer>");
+        if (args.Length == 3)
+            return CompletionResult.FromHint("<title>");
+        if (args.Length == 4)
+            return CompletionResult.FromHint("<text>");
+        if (args.Length == 5)
+            return CompletionResult.FromHintOptions(CompletionHelper.PrototypeIDs<EntityPrototype>(), "<icon entity>");
+
+        return CompletionResult.Empty;
+    }
+}

--- a/Content.Server/_ShibaStation/Objectives/Commands/CompleteCustomObjectiveCommand.cs
+++ b/Content.Server/_ShibaStation/Objectives/Commands/CompleteCustomObjectiveCommand.cs
@@ -1,0 +1,111 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.Objectives.Components;
+using Content.Server._ShibaStation.Objectives.Systems;
+using Content.Shared.Mind;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+
+namespace Content.Server._ShibaStation.Objectives.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class CompleteCustomObjectiveCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IPlayerManager _players = default!;
+
+    public string Command => "customobjectivestatus";
+    public string Description => "Sets a custom objective's progress value.";
+    public string Help => "customobjectivestatus <username> <objective ID> [progress (0.0-1.0)]";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length < 2)
+        {
+            shell.WriteError("Expected at least 2 arguments.");
+            return;
+        }
+
+        if (!_players.TryGetSessionByUsername(args[0], out var session))
+        {
+            shell.WriteError("Can't find the player.");
+            return;
+        }
+
+        var minds = _entityManager.System<SharedMindSystem>();
+        if (!minds.TryGetMind(session, out var mindId, out var mind))
+        {
+            shell.WriteError("Can't find the mind.");
+            return;
+        }
+
+        if (!EntityUid.TryParse(args[1], out var objectiveUid))
+        {
+            shell.WriteError("Invalid objective ID.");
+            return;
+        }
+
+        // Verify this objective belongs to the specified player
+        if (!mind.Objectives.Contains(objectiveUid))
+        {
+            shell.WriteError("That objective ID does not belong to the specified player.");
+            return;
+        }
+
+        if (!_entityManager.TryGetComponent<CustomObjectiveComponent>(objectiveUid, out var comp))
+        {
+            shell.WriteError("That objective ID does not correspond to a custom objective.");
+            return;
+        }
+
+        var progress = 1.0f; // Default to complete
+        if (args.Length > 2 && float.TryParse(args[2], out var parsedProgress))
+        {
+            progress = Math.Clamp(parsedProgress, 0f, 1f);
+        }
+
+        _entityManager.System<CustomObjectiveSystem>().SetProgress(objectiveUid, progress);
+        shell.WriteLine($"Set objective {objectiveUid} progress to {progress:P0}.");
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            return CompletionResult.FromHintOptions(
+                CompletionHelper.SessionNames(),
+                "username");
+        }
+
+        if (args.Length == 2)
+        {
+            // If we have a valid username, show their custom objectives
+            if (_players.TryGetSessionByUsername(args[0], out var session))
+            {
+                var minds = _entityManager.System<SharedMindSystem>();
+                if (minds.TryGetMind(session, out var mindId, out var mind))
+                {
+                    var options = new List<CompletionOption>();
+                    foreach (var objective in mind.Objectives)
+                    {
+                        if (!_entityManager.TryGetComponent<CustomObjectiveComponent>(objective, out var comp))
+                            continue;
+
+                        var meta = _entityManager.GetComponent<MetaDataComponent>(objective);
+                        options.Add(new CompletionOption(
+                            objective.ToString(),
+                            $"{meta.EntityName} ({(comp.Progress * 100):F0}%)"));
+                    }
+                    return CompletionResult.FromHintOptions(options, "objective ID");
+                }
+            }
+        }
+
+        if (args.Length == 3)
+        {
+            return CompletionResult.FromHint("progress (0.0-1.0)");
+        }
+
+        return CompletionResult.Empty;
+    }
+}

--- a/Content.Server/_ShibaStation/Objectives/Commands/RemoveCustomObjectiveCommand.cs
+++ b/Content.Server/_ShibaStation/Objectives/Commands/RemoveCustomObjectiveCommand.cs
@@ -1,0 +1,110 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.Objectives.Components;
+using Content.Shared.Mind;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Content.Server._ShibaStation.Objectives.Systems;
+
+namespace Content.Server._ShibaStation.Objectives.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class RemoveCustomObjectiveCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IPlayerManager _players = default!;
+
+    public string Command => "rmcustomobjective";
+    public string Description => "Removes a custom objective.";
+    public string Help => "rmcustomobjective <username> <objective ID>";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 2)
+        {
+            shell.WriteError("Expected exactly 2 arguments.");
+            return;
+        }
+
+        if (!_players.TryGetSessionByUsername(args[0], out var session))
+        {
+            shell.WriteError("Can't find the player.");
+            return;
+        }
+
+        var minds = _entityManager.System<SharedMindSystem>();
+        if (!minds.TryGetMind(session, out var mindId, out var mind))
+        {
+            shell.WriteError("Can't find the mind.");
+            return;
+        }
+
+        if (!EntityUid.TryParse(args[1], out var objectiveUid))
+        {
+            shell.WriteError("Invalid objective ID.");
+            return;
+        }
+
+        // Verify this objective belongs to the specified player
+        if (!mind.Objectives.Contains(objectiveUid))
+        {
+            shell.WriteError("That objective ID does not belong to the specified player.");
+            return;
+        }
+
+        if (!_entityManager.TryGetComponent<CustomObjectiveComponent>(objectiveUid, out var comp))
+        {
+            shell.WriteError("That objective ID does not correspond to a custom objective.");
+            return;
+        }
+
+        // Send notification to the player before removing the objective
+        if (mind.Session != null && mind.CurrentEntity != null)
+        {
+            var customSystem = _entityManager.System<CustomObjectiveSystem>();
+            customSystem.NotifyPlayer(mind.CurrentEntity.Value, mind.Session.Channel, "custom-objective-removed");
+        }
+
+        // Remove the objective
+        mind.Objectives.Remove(objectiveUid);
+        _entityManager.DeleteEntity(objectiveUid);
+
+        shell.WriteLine("Objective successfully removed!");
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            return CompletionResult.FromHintOptions(
+                CompletionHelper.SessionNames(),
+                "username");
+        }
+
+        if (args.Length == 2)
+        {
+            // If we have a valid username, show their custom objectives
+            if (_players.TryGetSessionByUsername(args[0], out var session))
+            {
+                var minds = _entityManager.System<SharedMindSystem>();
+                if (minds.TryGetMind(session, out var mindId, out var mind))
+                {
+                    var options = new List<CompletionOption>();
+                    foreach (var objective in mind.Objectives)
+                    {
+                        if (!_entityManager.TryGetComponent<CustomObjectiveComponent>(objective, out var comp))
+                            continue;
+
+                        var meta = _entityManager.GetComponent<MetaDataComponent>(objective);
+                        options.Add(new CompletionOption(
+                            objective.ToString(),
+                            $"{meta.EntityName} ({(comp.Progress * 100):F0}%)"));
+                    }
+                    return CompletionResult.FromHintOptions(options, "objective ID");
+                }
+            }
+        }
+
+        return CompletionResult.Empty;
+    }
+}

--- a/Content.Server/_ShibaStation/Objectives/Systems/CustomObjectiveSystem.cs
+++ b/Content.Server/_ShibaStation/Objectives/Systems/CustomObjectiveSystem.cs
@@ -1,0 +1,112 @@
+using Content.Shared.Mind;
+using Content.Shared.Objectives.Components;
+using Content.Shared.Objectives.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+using Content.Server.Chat.Systems;
+using Content.Server.Chat.Managers;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Player;
+using Content.Shared.Chat;
+using Robust.Shared.Network;
+
+namespace Content.Server._ShibaStation.Objectives.Systems;
+
+/// <summary>
+/// Handles custom objectives that can be added and controlled by admins.
+/// </summary>
+public sealed class CustomObjectiveSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly MetaDataSystem _metaData = default!;
+    [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CustomObjectiveComponent, ObjectiveGetProgressEvent>(OnGetProgress);
+        SubscribeLocalEvent<CustomObjectiveComponent, ObjectiveAfterAssignEvent>(OnAfterAssign);
+        SubscribeLocalEvent<CustomObjectiveComponent, GetCustomIssuerEvent>(OnGetCustomIssuer);
+    }
+
+    private void OnGetProgress(EntityUid uid, CustomObjectiveComponent comp, ref ObjectiveGetProgressEvent args)
+    {
+        args.Progress = comp.Progress;
+    }
+
+    private void OnAfterAssign(EntityUid uid, CustomObjectiveComponent comp, ref ObjectiveAfterAssignEvent args)
+    {
+        // Set the objective's title and description
+        _metaData.SetEntityName(uid, comp.Title, args.Meta);
+        _metaData.SetEntityDescription(uid, comp.Text, args.Meta);
+
+        // Send notification to the player when objective is added
+        if (args.Mind.Session != null && args.Mind.CurrentEntity != null)
+        {
+            NotifyPlayer(args.Mind.CurrentEntity.Value, args.Mind.Session.Channel, "custom-objective-received", ("issuer", comp.CustomIssuer));
+        }
+    }
+
+    private void OnGetCustomIssuer(EntityUid uid, CustomObjectiveComponent comp, ref GetCustomIssuerEvent args)
+    {
+        args.CustomIssuer = comp.CustomIssuer;
+    }
+
+    /// <summary>
+    /// Creates a new custom objective entity.
+    /// </summary>
+    public EntityUid CreateCustomObjective(string issuer, string title, string text, SpriteSpecifier? icon = null)
+    {
+        var objective = Spawn("AdminCustomObjective");
+
+        // Get the custom objective component
+        var customComp = Comp<CustomObjectiveComponent>(objective);
+        customComp.Title = title;
+        customComp.Text = text;
+        customComp.Progress = 0f;
+        customComp.CustomIssuer = issuer;
+
+        // Set initial metadata
+        _metaData.SetEntityName(objective, title);
+        _metaData.SetEntityDescription(objective, text);
+
+        // Set the icon if provided
+        if (icon != null)
+        {
+            var objComp = EnsureComp<ObjectiveComponent>(objective);
+            _objectives.SetIcon(objective, icon, objComp);
+        }
+
+        return objective;
+    }
+
+    /// <summary>
+    /// Sets a custom objective's progress value.
+    /// </summary>
+    public void SetProgress(EntityUid uid, float progress, CustomObjectiveComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp))
+            return;
+
+        var oldProgress = comp.Progress;
+        comp.Progress = Math.Clamp(progress, 0f, 1f);
+    }
+
+    /// <summary>
+    /// Sends a notification to a player about an objective change
+    /// </summary>
+    public void NotifyPlayer(EntityUid playerEntity, INetChannel channel, string messageKey, params (string, object)[] args)
+    {
+        // Send chat message
+        var message = Loc.GetString(messageKey, args);
+        var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", message));
+        _chatManager.ChatMessageToOne(ChatChannel.Server, message, wrappedMessage, playerEntity, false, channel);
+
+        // Play notification sound
+        _audio.PlayGlobal("/Audio/Misc/cryo_warning.ogg", Filter.Entities(playerEntity), false);
+    }
+}

--- a/Content.Shared/Objectives/Components/CustomObjectiveComponent.cs
+++ b/Content.Shared/Objectives/Components/CustomObjectiveComponent.cs
@@ -1,0 +1,44 @@
+using Content.Shared.Mind;
+using Content.Shared.Objectives.Systems;
+using Robust.Shared.Utility;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Audio;
+
+namespace Content.Shared.Objectives.Components;
+
+/// <summary>
+/// Extends ObjectiveComponent to support custom issuers.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CustomObjectiveComponent : Component
+{
+    /// <summary>
+    /// The custom issuer name for this objective.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string CustomIssuer = string.Empty;
+
+    /// <summary>
+    /// The title of this objective.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string Title = string.Empty;
+
+    /// <summary>
+    /// The description text for this objective.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string Text = string.Empty;
+
+    /// <summary>
+    /// The progress value of this objective (0.0 to 1.0).
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float Progress;
+
+    /// <summary>
+    /// The sound that plays for the player when this objective is added or removed.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier ObjectiveSound = new SoundPathSpecifier("/Audio/Misc/cryo_warning.ogg");
+}

--- a/Resources/Locale/en-US/_ShibaStation/objectives/custom-objective.ftl
+++ b/Resources/Locale/en-US/_ShibaStation/objectives/custom-objective.ftl
@@ -1,0 +1,2 @@
+custom-objective-received = You have received a new objective from {$issuer} (Press C to see your Objectives)
+custom-objective-removed = An objective has been removed from your list (Press C to see your Objectives)

--- a/Resources/Prototypes/_ShibaStation/Objectives/custom.yml
+++ b/Resources/Prototypes/_ShibaStation/Objectives/custom.yml
@@ -1,0 +1,13 @@
+- type: entity
+  parent: BaseObjective
+  id: AdminCustomObjective
+  noSpawn: true
+  components:
+  - type: Objective
+    difficulty: 0
+    unique: false
+    issuer: objective-issuer-admin
+    icon:
+      sprite: Interface/Misc/job_icons.rsi
+      state: Generic
+  - type: CustomObjective


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds several commands designed to allow admins to give users custom objectives, for admeme purposes.

`customobjective [username] [issuer] [title] [description] [icon]`
`customobjectivestatus [username] [id] [0.0-1.0]`
`rmcustomobjective [username] [id]`

e.g. `customobjective JohnUsername "Central Command" "Eat Paper" "Eat 10 pieces of paper. Yummers!"`

...would give JohnUsername the custom objective issued by 'Central Command' to 'Eat Paper' with the description outlining the task.

None of this is tracked, that's a huge ask - instead admins can update the status of an objective using the `customobjectivestatus` command and can use a float to effectively mark an objective from 0%-100% completed.

Implemented proper autocomplete too so you don't have to go grabbing objective IDs from a list or type out long ass usernames. Exceptionally user friendly!

**To Do:**
- [ ] Implement proper notification to the user when their objectives get added/removed
- [ ] Display custom objectives at the end of round screen for extra funnies
- [ ] Fix the default icon so it's *something* (idk what yet)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Just an extra layer of fun for admins to help drive admin events or other silly admemes with.

## Technical details
<!-- Summary of code changes for easier review. -->
see diffs ><

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![SS14 Loader_l3VTQQGrSA](https://github.com/user-attachments/assets/142718f8-4ffe-4012-8e2c-c279ff11d2e9)