### PR TITLE
Adjust Air Alarm Threshold Defaults

### DIFF
--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -24,15 +24,26 @@
     threshold: 550 # HazardHighPressure from Atmospherics.cs
   lowerBound: !type:AlarmThresholdSetting
     # Actual low pressure damage threshold is at 20 kPa, but below ~85 kPa you can't breathe due to lack of oxygen.
-    threshold: 85
+    threshold: 40 # DeltaV - was 80
   upperWarnAround: !type:AlarmThresholdSetting
     threshold: 0.7 # 385 kPa, WarningHighPressure from Atmospherics.cs
   lowerWarnAround: !type:AlarmThresholdSetting
-    threshold: 1.05 # ~90 kPa
+    threshold: 2 # DeltaV - 80kpa, was 1.05 (90kpa)
 
 # For gas concentrations, threshold=0.1 means 10%
 - type: alarmThreshold
   id: stationOxygen
+  lowerBound: !type:AlarmThresholdSetting
+    threshold: 0.10
+  upperBound: !type:AlarmThresholdSetting
+    threshold: 0.8 # DeltaV - was 0.3, ridiculous
+  lowerWarnAround: !type:AlarmThresholdSetting
+    threshold: 1.5
+  upperWarnAround: !type:AlarmThresholdSetting
+    threshold: 0.8
+
+- type: alarmThreshold
+  id: stationNitrogen
   lowerBound: !type:AlarmThresholdSetting
     threshold: 0.10
   lowerWarnAround: !type:AlarmThresholdSetting


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Basically just ripped https://github.com/DeltaV-Station/Delta-v/pull/2939 off wholesale :^)
Also included some missing values that DeltaV has that we don't.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The air alarm defaults were also pissing me off but I haven't had enough chance to sit and tinker with the values enough to truly understand what works best. I trust deltanedas's knowledge on this blindly. 

I had already made some adjustments for the additional gasses we have via Goob (BZ, Nitrium and Pluoxium), so hopefully this will make air alarms less cringe overall.

## Technical details
<!-- Summary of code changes for easier review. -->
see diffs guh