### PR TITLE
Greatly adjusts antag/ghost role time requirements

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -21,6 +21,9 @@
     rules: ghost-role-information-freeagent-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
   - type: GhostRoleMobSpawner
     prototype: MobRatKing
   - type: Sprite
@@ -42,6 +45,9 @@
     rules: ghost-role-information-familiar-rules
     raffle:
       settings: short
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 36000 # 10 hours
   - type: GhostRoleMobSpawner
     prototype: MobBatRemilia
   - type: Sprite
@@ -63,6 +69,9 @@
     rules: ghost-role-information-familiar-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
   - type: GhostRoleMobSpawner
     prototype: MobCorgiCerberus
   - type: Sprite
@@ -83,6 +92,12 @@
     rules: ghost-role-information-rules-team-antagonist
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 # 20 hours
   - type: GhostRoleMobSpawner
     prototype: MobHumanNukeOp
   - type: Sprite
@@ -101,6 +116,12 @@
     name: ghost-role-information-loneop-name
     description: ghost-role-information-loneop-description
     rules: ghost-role-information-loneop-rules
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 # 20 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:
@@ -117,6 +138,12 @@
     name: roles-antag-nuclear-operative-commander-name
     description: roles-antag-nuclear-operative-commander-objective
     rules: ghost-role-information-rules-team-antagonist
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 # 20 hours
 
 - type: entity
   categories: [ HideSpawnMenu, Spawner ]
@@ -127,6 +154,12 @@
     name: roles-antag-nuclear-operative-agent-name
     description: roles-antag-nuclear-operative-agent-objective
     rules: ghost-role-information-rules-team-antagonist
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 # 20 hours
 
 - type: entity
   categories: [ HideSpawnMenu, Spawner ]
@@ -137,6 +170,12 @@
     name: roles-antag-nuclear-operative-name
     description: roles-antag-nuclear-operative-objective
     rules: ghost-role-information-rules-team-antagonist
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 # 20 hours
 
 - type: entity
   categories: [ HideSpawnMenu, Spawner ]
@@ -147,6 +186,12 @@
     name: ghost-role-information-space-dragon-name
     description: ghost-role-information-space-dragon-description
     rules: ghost-role-information-space-dragon-rules
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 # 20 hours
   - type: Sprite
     layers:
     - state: green
@@ -162,6 +207,12 @@
     name: ghost-role-information-space-ninja-name
     description: ghost-role-information-space-ninja-description
     rules: ghost-role-information-antagonist-rules
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 # 20 hours
     raffle:
       settings: default
   - type: Sprite
@@ -182,6 +233,12 @@
     rules: ghost-role-information-silicon-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 # 20 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1464,6 +1464,9 @@
     rules: ghost-role-information-syndicate-reinforcement-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
   - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [SyndicateOperativeGearMonkey]
@@ -2493,6 +2496,12 @@
     rules: ghost-role-information-giant-spider-rules
     raffle:
       settings: short
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -3021,6 +3030,9 @@
     rules: ghost-role-information-SyndiCat-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 36000 # 10 hours
   - type: GhostTakeoverAvailable
   - type: AutoImplant
     implants:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -13,6 +13,9 @@
       rules: ghost-role-information-antagonist-rules
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
     - type: GhostTakeoverAvailable
     - type: HTN
       rootTask:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -234,6 +234,9 @@
     rules: ghost-role-information-angry-slimes-rules
     raffle:
       settings: short
+    requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
   - type: NpcFactionMember
     factions:
     - SimpleHostile

--- a/Resources/Prototypes/Entities/Mobs/NPCs/hellspawn.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/hellspawn.yml
@@ -15,6 +15,12 @@
     rules: ghost-role-information-antagonist-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: RotationVisuals
     defaultRotation: 90
     horizontalRotation: 90

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -797,6 +797,9 @@
     name: ghost-role-information-punpun-name
     description: ghost-role-information-punpun-description
     rules: ghost-role-information-nonantagonist-rules
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 36000 # 10 hours
   - type: GhostTakeoverAvailable
   - type: Butcherable
     butcheringType: Spike

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -98,6 +98,9 @@
     rules: ghost-role-information-freeagent-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
   - type: GhostTakeoverAvailable
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -40,6 +40,12 @@
     rules: ghost-role-information-antagonist-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: GhostTakeoverAvailable
   - type: Revenant
     malfunctionWhitelist:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -135,6 +135,12 @@
     rules: ghost-role-information-nonantagonist-rules
     raffle:
       settings: short
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: Speech
     speechVerb: Slime
     speechSounds: Slime
@@ -174,6 +180,12 @@
       rules: ghost-role-information-angry-slimes-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
 
 - type: entity
   name: green slime
@@ -212,6 +224,12 @@
       rules: ghost-role-information-angry-slimes-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
 
 - type: entity
   name: yellow slime
@@ -249,3 +267,9 @@
       rules: ghost-role-information-angry-slimes-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -104,6 +104,12 @@
     rules: ghost-role-information-xeno-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 20 hours
   - type: GhostTakeoverAvailable
   - type: TypingIndicator
     proto: alien

--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
@@ -426,7 +426,7 @@
     - type: RandomMetadata
       nameSegments:
       - names_clown
-      
+
 - type: randomHumanoidSettings
   id: VisitorJanitor
   parent: VisitorCivilian
@@ -742,6 +742,12 @@
       rules: ghost-role-information-rules-team-antagonist
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
     - type: Loadout
       prototypes: [ SyndicateFootsoldierTeamLeaderGear ]
       roleLoadout: [ RoleSurvivalSyndicate ]
@@ -760,6 +766,12 @@
       rules: ghost-role-information-rules-team-antagonist
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 180000 # 50 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 20 hours
     - type: Loadout
       prototypes: [ SyndicateFootsoldierGear ]
       roleLoadout: [ RoleSurvivalSyndicate ]
@@ -777,6 +789,12 @@
       rules: ghost-role-information-freeagent-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
     - type: Loadout
       prototypes: [ SyndicateOperativeGearCivilian ]
       roleLoadout: [ RoleSurvivalSyndicate ]
@@ -794,6 +812,12 @@
       rules: ghost-role-information-rules-team-antagonist
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
     - type: Loadout
       prototypes: [ PirateScoonerAltA, PirateScoonerAltB, PirateScoonerAltC, PirateScoonerAltD ]
       roleLoadout: [ RoleSurvivalEVA ]
@@ -811,6 +835,12 @@
       rules: ghost-role-information-rules-team-antagonist
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
     - type: Loadout
       prototypes: [ PirateCaptainScooner ]
       roleLoadout: [ RoleSurvivalEVA ]
@@ -827,6 +857,12 @@
       rules: ghost-role-information-freeagent-rules
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
     - type: Loadout
       prototypes: [ VisitorBlackmarketeer, VisitorBlackmarketeer ]
       roleLoadout: [ RoleSurvivalStandard ]
@@ -845,6 +881,12 @@
       rules: ghost-role-information-freeagent-rules
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
     - type: Loadout
       prototypes: [ CossackGear ]
       roleLoadout: [ RoleSurvivalEVA ]

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -24,6 +24,12 @@
     rules: ghost-role-information-space-dragon-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 # 20 hours
   - type: GhostTakeoverAvailable
   - type: HTN
     rootTask:

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -11,6 +11,9 @@
     name: ghost-role-information-remilia-name
     description: ghost-role-information-remilia-description
     rules: ghost-role-information-familiar-rules
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 36000 # 10 hours
   - type: GhostTakeoverAvailable
   - type: Grammar
     attributes:
@@ -46,6 +49,9 @@
     rules: ghost-role-information-familiar-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 36000 # 10 hours
   - type: GhostTakeoverAvailable
   - type: MeleeWeapon
     altDisarm: false

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -16,6 +16,9 @@
       rules: ghost-role-information-familiar-rules
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
     - type: GhostTakeoverAvailable
     - type: Input
       context: "human"
@@ -126,6 +129,9 @@
       rules: ghost-role-information-familiar-rules
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
     - type: GhostTakeoverAvailable
     - type: NameIdentifier
       group: Holoparasite
@@ -159,6 +165,9 @@
       rules: ghost-role-information-familiar-rules
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
     - type: GhostTakeoverAvailable
     - type: RandomSprite
       available:
@@ -194,6 +203,9 @@
       rules: ghost-role-information-familiar-rules
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
     - type: GhostTakeoverAvailable
     - type: NameIdentifier
       group: Holoparasite

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -64,6 +64,12 @@
       rules: ghost-role-information-Death-Squad-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
     - type: Loadout
       prototypes: [ DeathSquadGear ]
       roleLoadout: [ RoleSurvivalEVA ]
@@ -101,6 +107,12 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
       job: ERTLeader
     - type: Loadout
       prototypes: [ ERTLeaderGear ]
@@ -132,6 +144,12 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
       job: ERTLeader
     - type: Loadout
       prototypes: [ ERTLeaderGearEVA ]
@@ -155,6 +173,12 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
       job: ERTLeader
     - type: Loadout
       prototypes: [ ERTLeaderGearEVALecter ]
@@ -189,6 +213,9 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
       job: ERTChaplain
     - type: RandomMetadata
       nameSegments:
@@ -220,6 +247,9 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
       job: ERTChaplain
     - type: Loadout
       prototypes: [ ERTChaplainGearEVA ]
@@ -254,6 +284,9 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
       job: ERTJanitor
     - type: RandomMetadata
       nameSegments:
@@ -285,6 +318,9 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
       job: ERTJanitor
     - type: Loadout
       prototypes: [ ERTJanitorGearEVA ]
@@ -318,6 +354,9 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
       job: ERTEngineer
     - type: RandomMetadata
       nameSegments:
@@ -349,6 +388,9 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
       job: ERTEngineer
     - type: Loadout
       prototypes: [ ERTEngineerGearEVA ]
@@ -382,6 +424,9 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
       job: ERTSecurity
     - type: RandomMetadata
       nameSegments:
@@ -413,6 +458,9 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
       job: ERTSecurity
     - type: Loadout
       prototypes: [ ERTSecurityGearEVA ]
@@ -436,6 +484,9 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
       job: ERTSecurity
     - type: Loadout
       prototypes: [ ERTSecurityGearEVALecter ]
@@ -469,6 +520,9 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
       job: ERTMedical
     - type: RandomMetadata
       nameSegments:
@@ -500,6 +554,9 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 36000 # 10 hours
       job: ERTMedical
     - type: Loadout
       prototypes: [ ERTMedicalGearEVA ]
@@ -531,6 +588,12 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
     - type: RandomMetadata
       nameSegments:
       - NamesFirstMilitary

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -378,7 +378,7 @@
     unlistedNumber: true
     requiresPower: false
   - type: Holopad
-  - type: StationAiWhitelist  
+  - type: StationAiWhitelist
   - type: UserInterface
     interfaces:
         enum.HolopadUiKey.AiRequestWindow:
@@ -537,6 +537,12 @@
       rules: ghost-role-information-silicon-rules
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 180000 # 50 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 72000 # 20 hours
     - type: GhostTakeoverAvailable
 
 - type: entity
@@ -570,6 +576,12 @@
       rules: ghost-role-information-silicon-rules
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 180000 # 50 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 72000 # 20 hours
     - type: GhostTakeoverAvailable
 
 - type: entity
@@ -620,4 +632,10 @@
       rules: ghost-role-information-silicon-rules
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 180000 # 50 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 72000 # 20 hours
     - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -20,6 +20,12 @@
     rules: ghost-role-information-freeagent-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [PirateGear]
@@ -37,6 +43,12 @@
     rules: ghost-role-information-freeagent-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [SkeletonBiker]
@@ -53,6 +65,9 @@
     rules: ghost-role-information-nonantagonist-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 36000 # 10 hours
   - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [LimitedPassengerGear]

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -28,6 +28,12 @@
     rules: ghost-role-information-syndicate-reinforcement-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: GhostRoleMobSpawner
     prototype: MobHumanSyndicateAgentSpy
     selectablePrototypes: ["SyndicateAgentMedic", "SyndicateAgentSpy", "SyndicateAgentThief"]
@@ -46,6 +52,12 @@
     rules: ghost-role-information-nukeop-reinforcement-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 # 20 hours
   - type: GhostRoleMobSpawner
     prototype: MobHumanSyndicateAgentNukeops
 
@@ -61,6 +73,12 @@
     rules: ghost-role-information-syndicate-reinforcement-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: GhostRoleMobSpawner
     prototype: MobMonkeySyndicateAgent
     selectablePrototypes: ["SyndicateMonkey", "SyndicateKobold"]
@@ -72,6 +90,12 @@
   components:
   - type: GhostRole
     rules: ghost-role-information-nukeop-reinforcement-rules
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 # 20 hours
   - type: GhostRoleMobSpawner
     prototype: MobMonkeySyndicateAgentNukeops
     selectablePrototypes: ["SyndicateMonkeyNukeops", "SyndicateKoboldNukeops"]
@@ -88,6 +112,9 @@
     rules: ghost-role-information-syndicate-reinforcement-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 36000 # 10 hours
   - type: GhostRoleMobSpawner
     prototype: MobCatSyndy
   - type: EmitSoundOnUse
@@ -106,5 +133,11 @@
       rules: ghost-role-information-silicon-rules
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 180000 # 50 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 72000 # 20 hours
     - type: GhostRoleMobSpawner
       prototype: PlayerBorgSyndicateAssaultBattery

--- a/Resources/Prototypes/Roles/Antags/dragon.yml
+++ b/Resources/Prototypes/Roles/Antags/dragon.yml
@@ -3,3 +3,9 @@
   name: roles-antag-dragon-name
   antagonist: true
   objective: roles-antag-dragon-objective
+  requirements: # ShibaStation - Antag Playtime Requirements
+  - !type:OverallPlaytimeRequirement
+    time: 72000 # 20 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 36000 # 10 hours

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -5,6 +5,12 @@
   setPreference: false
   objective: roles-antag-space-ninja-objective
   guides: [ SpaceNinja ]
+  requirements: # ShibaStation - Antag Playtime Requirements
+  - !type:OverallPlaytimeRequirement
+    time: 72000 # 20 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 36000 # 10 hours
 
 #Ninja Gear
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -6,7 +6,10 @@
   objective: roles-antag-nuclear-operative-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
+    time: 180000 # 50 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 72000 # 20 hours
   guides: [ NuclearOperatives ]
 
 - type: antag
@@ -17,10 +20,13 @@
   objective: roles-antag-nuclear-operative-agent-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
+    time: 180000 # 50 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 72000 # 20 hours
   - !type:RoleTimeRequirement
     role: JobChemist
-    time: 10800 # 3h
+    time: 18000 # 5 hours
   guides: [ NuclearOperatives ]
 
 - type: antag
@@ -31,10 +37,10 @@
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
+    time: 180000 # 50 hours
   - !type:DepartmentTimeRequirement
     department: Security
-    time: 18000 # 5h
+    time: 108000 # 30 hours
   # should be changed to nukie playtime when thats tracked (wyci)
   guides: [ NuclearOperatives ]
 

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -5,8 +5,11 @@
   setPreference: true
   objective: roles-antag-rev-head-objective
   requirements:
-    - !type:OverallPlaytimeRequirement
-      time: 36000 # 10h
+  - !type:OverallPlaytimeRequirement
+    time: 72000 # 20 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 36000 # 10 hours
   guides: [ Revolutionaries ]
 
 - type: antag

--- a/Resources/Prototypes/Roles/Antags/silicon.yml
+++ b/Resources/Prototypes/Roles/Antags/silicon.yml
@@ -4,3 +4,10 @@
   antagonist: true
   setPreference: false
   objective: roles-antag-subverted-silicon-objective
+  requirements: # ShibaStation - Antag Playtime Requirements
+  - !type:OverallPlaytimeRequirement
+    time: 72000 # 20 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 36000 # 10 hours
+

--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -5,6 +5,12 @@
   setPreference: true
   objective: roles-antag-thief-objective
   guides: [ Thieves ]
+  requirements: # ShibaStation - Antag Playtime Requirements
+  - !type:OverallPlaytimeRequirement
+    time: 36000 # 10 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 18000 # 5 hours
 
 - type: startingGear
   id: ThiefGear

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -5,6 +5,12 @@
   setPreference: true
   objective: roles-antag-syndicate-agent-objective
   guides: [ Traitors ]
+  requirements: # ShibaStation - Antag Playtime Requirements
+  - !type:OverallPlaytimeRequirement
+    time: 72000 # 20 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 36000 # 10 hours
 
 - type: antag
   id: TraitorSleeper
@@ -13,6 +19,12 @@
   setPreference: true
   objective: roles-antag-syndicate-agent-sleeper-objective
   guides: [ Traitors ]
+  requirements: # ShibaStation - Antag Playtime Requirements
+  - !type:OverallPlaytimeRequirement
+    time: 72000 # 20 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 36000 # 10 hours
 
 # Syndicate Operative Outfit - Monkey
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -9,6 +9,11 @@
     inverted: true
     species:
     - IPC
+  - !type:OverallPlaytimeRequirement
+    time: 72000 # 20 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 36000 # 10 hours
   guides: [ Zombies ]
 
 - type: antag

--- a/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
@@ -195,6 +195,9 @@
     rules: ghost-role-information-freeagent-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
   - type: GhostTakeoverAvailable
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.25

--- a/Resources/Prototypes/_Goobstation/Blob/blob_mobs.yml
+++ b/Resources/Prototypes/_Goobstation/Blob/blob_mobs.yml
@@ -122,6 +122,12 @@
       rules: You are an antagonist, defend your blob core!
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
     - type: GhostTakeoverAvailable
     - type: Blobbernaut
     - type: Physics
@@ -230,6 +236,12 @@
       name: ghost-role-information-blob-name
       description: ghost-role-information-blob-description
       rules: You are an antagonist, destroy the station!
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 180000 # 50 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 72000 # 20 hours
     - type: GhostTakeoverAvailable
     - type: Fixtures
       fixtures:

--- a/Resources/Prototypes/_Goobstation/Blob/blob_tiles.yml
+++ b/Resources/Prototypes/_Goobstation/Blob/blob_tiles.yml
@@ -12,6 +12,12 @@
       rules: You are an antagonist, destroy the station!
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 180000 # 50 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 72000 # 20 hours
     - type: Sprite
       sprite: Markers/jobs.rsi
       layers:
@@ -96,6 +102,12 @@
     reregister: false
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 72000 # 20 hours
   - type: GhostTakeoverAvailable
 
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Blob/misc_blob.yml
+++ b/Resources/Prototypes/_Goobstation/Blob/misc_blob.yml
@@ -48,6 +48,12 @@
       rules: blob-carrier-role-rules
       raffle:
         settings: default
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 180000 # 50 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 72000 # 20 hours
     - type: Sprite
       sprite: Markers/jobs.rsi
       layers:

--- a/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
@@ -4,9 +4,12 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-changeling-description
-  requirements:
+  requirements: # ShibaStation - Antag Playtime Requirements
   - !type:OverallPlaytimeRequirement
-      time: 36000 #10 hrs
+    time: 72000 # 20 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 36000 # 10 hours
   - !type:SpeciesRequirement
     inverted: true
     species:

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
@@ -137,6 +137,9 @@
     rules: ghost-role-information-SyndiRoach-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 36000 # 10 hours
   - type: GhostTakeoverAvailable
   - type: AutoImplant
     implants:
@@ -209,6 +212,9 @@
     name: ghost-role-information-lootbug-name
     description: ghost-role-information-lootbug-description
     rules: ghost-role-information-freeagent-rules
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
   - type: GhostTakeoverAvailable
   - type: Speech
     speechVerb: SmallMob

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/humanoid.yml
@@ -208,6 +208,12 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: short
+      requirements: # ShibaStation - Antag Playtime Requirements
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20 hours
+      - !type:DepartmentTimeRequirement
+        department: Security
+        time: 36000 # 10 hours
       job: ERTSecurity
     - type: Loadout
       prototypes: [ ERTSecurityGearEVAAnnie ]

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -10,6 +10,9 @@
     rules: ghost-role-information-SyndiRoach-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 36000 # 10 hours
   - type: GhostRoleMobSpawner
     prototype: MobMothSyndy
   - type: EmitSoundOnUse

--- a/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
@@ -4,9 +4,12 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-heretic-description
-  requirements:
+  requirements: # ShibaStation - Antag Playtime Requirements
   - !type:OverallPlaytimeRequirement
-    time: 54000 # 15h
+    time: 72000 # 20 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 36000 # 10 hours
   guides: [ Heretics ]
 
 - type: startingGear

--- a/Resources/Prototypes/_Goobstation/Roles/Antags/blob.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Antags/blob.yml
@@ -7,4 +7,7 @@
   guides: [ Blob ]
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h # Goobstation-RoleTime
+    time: 180000 # 50 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 72000 # 20 hours

--- a/Resources/Prototypes/_Goobstation/Wizard/wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/wizard.yml
@@ -24,10 +24,14 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-wizard-description
-  requirements:
+  requirements: # ShibaStation - Antag Playtime Requirements
   - !type:OverallPlaytimeRequirement
-    time: 54000 # 15h
+    time: 360000 # 100 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 180000 # 50 hours
   guides: [ Wizard ]
+
 
 - type: antag
   id: Apprentice
@@ -35,6 +39,12 @@
   antagonist: true
   setPreference: false
   objective: roles-antag-apprentice-description
+  requirements: # ShibaStation - Antag Playtime Requirements
+  - !type:OverallPlaytimeRequirement
+    time: 180000 # 50 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 72000 # 20 hours
 
 - type: entity
   categories: [ HideSpawnMenu, Spawner ]

--- a/Resources/Prototypes/_Goobstation/Wizard/wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/wizard.yml
@@ -45,6 +45,12 @@
     name: roles-wizard-name
     description: roles-wizard-objective
     rules: ghost-role-information-antagonist-rules
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 360000 # 100 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 180000 # 50 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:

--- a/Resources/Prototypes/_Shitmed/Entities/Mobs/Player/abductor.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Mobs/Player/abductor.yml
@@ -31,6 +31,12 @@
     rules: abductors-ghost-role-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: AbductorScientist
   - type: ActionGrant
     actions:
@@ -56,6 +62,12 @@
     rules: abductors-ghost-role-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: AbductorScientist
   - type: ActionGrant
     actions:
@@ -78,6 +90,12 @@
     rules: abductors-ghost-role-rules
     raffle:
       settings: default
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: AbductorScientist
   - type: ActionGrant
     actions:
@@ -146,6 +164,12 @@
     name: abductors-ghost-role-name
     description: abductors-ghost-role-desc
     rules: abductors-ghost-role-rules
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:
@@ -175,6 +199,12 @@
     name: abductors-ghost-role-name
     description: abductors-ghost-role-desc
     rules: abductors-ghost-role-rules
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:
@@ -204,6 +234,12 @@
     name: abductors-ghost-role-name
     description: abductors-ghost-role-desc
     rules: abductors-ghost-role-rules
+    requirements: # ShibaStation - Antag Playtime Requirements
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:

--- a/Resources/Prototypes/_Shitmed/Entities/Mobs/Player/abductor.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Mobs/Player/abductor.yml
@@ -35,7 +35,7 @@
     - !type:OverallPlaytimeRequirement
       time: 72000 # 20 hours
     - !type:DepartmentTimeRequirement
-      department: Security
+      department: Medical
       time: 36000 # 10 hours
   - type: AbductorScientist
   - type: ActionGrant
@@ -66,7 +66,7 @@
     - !type:OverallPlaytimeRequirement
       time: 72000 # 20 hours
     - !type:DepartmentTimeRequirement
-      department: Security
+      department: Medical
       time: 36000 # 10 hours
   - type: AbductorScientist
   - type: ActionGrant
@@ -168,7 +168,7 @@
     - !type:OverallPlaytimeRequirement
       time: 72000 # 20 hours
     - !type:DepartmentTimeRequirement
-      department: Security
+      department: Medical
       time: 36000 # 10 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
@@ -238,7 +238,7 @@
     - !type:OverallPlaytimeRequirement
       time: 72000 # 20 hours
     - !type:DepartmentTimeRequirement
-      department: Security
+      department: Medical
       time: 36000 # 10 hours
   - type: Sprite
     sprite: Markers/jobs.rsi

--- a/Resources/Prototypes/_Shitmed/Roles/Antags/abductor.yml
+++ b/Resources/Prototypes/_Shitmed/Roles/Antags/abductor.yml
@@ -3,6 +3,12 @@
   name: abductors-ghost-role-name
   antagonist: true
   objective: roles-antag-abductor-objective
+  requirements: # ShibaStation - Antag Playtime Requirements
+  - !type:OverallPlaytimeRequirement
+    time: 72000 # 20 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 36000 # 10 hours
 
 - type: antag
   id: AbductorVictimAntag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
All antagonist and A LOT of ghost roles now have playtime requirements either added or adjusted to be harsher.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We're an MRP server and we're working hard to discourage sweatgaming and gotta-greentext mentality. LRP is there for the minute-to-minute action-only gameplay but we're trying to find the right balance that incorporates more RP. The raised requirements, which for most antagonists is a reasonable ten shifts or less, should help ensure that 'the right people' are taking antagonist roles.

Additionally this helps discourage and in some cases flat out eliminate 'antag vagrancy' where people will join servers just to roll antag only. We see you and we don't like you, go back to LRP, please!

Finally this works as a bit of a firebreak for now while I continue working on getting antag and ghost role bans working correctly (so close, just a week away!)

## Technical details
<!-- Summary of code changes for easier review. -->
All YAML, just added the reqs to the ghost roles and antag defs. There's some redundancy because... there's already redundancy in how some ghost roles are defined. There might also be some inconsistency because it's late and my eyes were starting to glaze over with how many of these things there are.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
imagine a very upset antag roller not being able to roll lone op on a shift with 12 players and no security.
