### PR TITLE
Rodentians are mousetrap-proof

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -101,7 +101,7 @@
       Female: FemaleRodentia
       Unsexed: MaleRodentia
   - type: Rummager
-  - type: AlwaysTriggerMousetrap
+  # - type: AlwaysTriggerMousetrap # ShibaStation - funny meme but disabled due to feedback
   - type: PseudoItem
     storedOffset: -10,0
     shape:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Rodentians no longer set off mousetraps.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's a funny meme, it does kinda make sense and also helps balance their ability to sneak a little, however it also ends up just being more of a general hindrance than a proper balancing thing. For now, this is a stop-gap solution.

In retrospect, I may attempt to add a new component in the future (see, soon™) to only apply the mousetrap triggering if a rodentian is _sneaking_ - at least that way they can still get caught out by hidden traps under tables if they try to go under, instead of climbing over top. For now, though, it's just a straight immunity.

## Technical details
<!-- Summary of code changes for easier review. -->
Disabled one line in YAML, lmao
