### PR TITLE
Salvage Locator on Salvage Shuttle (Salvage Magnet removed from Stations)

### DIFF
--- a/Resources/Maps/Shuttles/mining.yml
+++ b/Resources/Maps/Shuttles/mining.yml
@@ -11,13 +11,26 @@ tilemap:
 entities:
 - proto: ""
   entities:
+  - uid: 163
+    components:
+    - type: MetaData
+      name: Map Entity
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
+    - type: LoadedMap
   - uid: 181
     components:
     - type: MetaData
       name: NT-Reclaimer
     - type: Transform
       pos: 2.2710133,-2.4148211
-      parent: invalid
+      parent: 163
     - type: MapGrid
       chunks:
         -1,0:
@@ -83,6 +96,7 @@ entities:
             184: -1,-5
             188: -6,1
             189: -5,1
+            190: -5,-1
         - node:
             color: '#A4610696'
             id: CheckerNWSE
@@ -1220,6 +1234,14 @@ entities:
     - type: Transform
       pos: -4.5,-6.5
       parent: 181
+- proto: SalvageLocator
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 181
 - proto: SheetPlasma
   entities:
   - uid: 58
@@ -1242,6 +1264,14 @@ entities:
         - Pressed: Toggle
         47:
         - Pressed: Toggle
+- proto: SignMagneticsMed
+  entities:
+  - uid: 166
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 181
 - proto: SMESBasic
   entities:
   - uid: 1

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -736,3 +736,6 @@ LightTree06: LightTree
 VendingMachineRestockSalvageEquipment: null
 ComputerSalvageExpedition: ComputerShuttleMiningLavaland
 SalvageExpeditionsComputerCircuitboard: LavalandShuttleConsoleCircuitboard
+
+# 2025-02-26 # ShibaStation - Remove SalvageMagnet from stations and only keep SalvageLocator on Salvage Shuttle
+SalvageMagnet: null


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Puts the 'Salvage Locator' on the Salvage Shuttle and removes the 'Salvage Magnet' from stations via `migrations.yml`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It made little sense to keep on the station when we have the shuttle anyway; almost all salvagers would take it off the station (which was always allowed) and install it on the shuttle. This just streamlines that process entirely.

Since the Salvage Magnet and Salvage Locator are different entities, it was easy to yoink the Magnet via migrations and install the Locator to the shuttle - plus it draws less power which is ideal since the changes made to the shuttle earlier mean it requires fuelling.

## Technical details
<!-- Summary of code changes for easier review. -->
Added line to `migrations.yml` and mapped the Salvage Locator to the shuttle.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![SS14 Loader_dVlxr0KUDK](https://github.com/user-attachments/assets/27b09e50-64f1-4847-87b1-e80eda7ef6bd)
The magnet is actually rotated to face out the blast doors since salvage gets pulled in the direction it faces, I just didn't get a newer screenshot :)
