### PR TITLE
Lavaland name tweaks

### DIFF
--- a/Resources/Locale/en-US/_Lavaland/salvage/lavaland_names.ftl
+++ b/Resources/Locale/en-US/_Lavaland/salvage/lavaland_names.ftl
@@ -1,5 +1,5 @@
 lavaland-planet-name-unknown = Unknown Planet
-lavaland-planet-name-lavaland = Lavaland Planet
+lavaland-planet-name-lavaland = GS25 Lavaland HR-031
 lavaland-planet-name-icemoon = IceMoon
 
 # GPS Signals

--- a/Resources/Maps/_Lavaland/mining.yml
+++ b/Resources/Maps/_Lavaland/mining.yml
@@ -15,7 +15,7 @@ entities:
   - uid: 1
     components:
     - type: MetaData
-      name: Mining Shuttle
+      name: Lavaland Transport # ShibaStation - rename for clarity since we have returned the Salvage Shuttle
     - type: Transform
     - type: MapGrid
       chunks:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Renamed the lavaland planet and related shuttle.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
`Lavaland Planet` looked god awful next to the station name on the list which usually has some flavour suffixes and prefixes to make them sound all fancy and technical. Since I don't believe it's possible to apply randomised template strings to .ftl files, the lavaland planet will always have the same name, but it'll at least not stick out like a sore thumb.

The `Mining Shuttle` has been renamed to `Lavaland Transport` to alleviate any possible confusion over the reimplemented `Salvage Shuttle`. Besides, you can't pilot the thing that takes you to Lavaland, it only FTLs to fixed positions, so a 'transport' feels more apt.

Ultimately it's all purely petty and aesthetic.

## Technical details
<!-- Summary of code changes for easier review. -->
.ftl and prototype changes - single line each, no code.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![SS14 Loader_xtP4aFt9um](https://github.com/user-attachments/assets/99db9f65-188f-439a-b4ad-f650d7003b2e)
![SS14 Loader_wY9R77kiUE](https://github.com/user-attachments/assets/bf11b303-9534-403e-b8ea-60061e835b12)
