### PR TITLE
Fix Vox Air Alarms

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/vox.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/vox.yml
@@ -18,6 +18,7 @@
       BZ: danger # Assmos - /tg/ gases
       Healium: stationNO # Assmos - /tg/ gases
       Nitrium: danger # Assmos - /tg/ gases
+      Pluoxium: voxOxygen # Assmos - /tg/ gases
 
 - type: entity
   parent: [AirSensorVoxBase, AirSensor]
@@ -45,6 +46,7 @@
     - BZ
     - Healium
     - Nitrium
+    - Pluoxium
 
 # use this to prevent overriding filters with hardcoded defaults
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed vox air alarms breaking the client by adding the missing Pluoxium entries.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
game break not gud, now not break so is gud

## Technical details
<!-- Summary of code changes for easier review. -->
Added 'Pluoxium' to Vox-related atmos stuff
