### PR TITLE
Unique screen overlays for lavaland shuttle and salvage shuttle consoles

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -269,7 +269,7 @@
         - map: ["computerLayerKeyboard"]
           state: generic_keyboard
         - map: ["computerLayerScreen"]
-          state: shuttle
+          state: eris_control
         - map: ["computerLayerKeys"]
           state: generic_keys
     - type: DroneConsole

--- a/Resources/Prototypes/_Lavaland/Entities/Structures/computers.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Structures/computers.yml
@@ -10,7 +10,7 @@
     - map: [ "computerLayerKeyboard" ]
       state: generic_keyboard
     - map: [ "computerLayerScreen" ]
-      state: shuttle
+      state: mining
     - map: ["computerLayerKeys" ]
       state: generic_keys
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Replaced the lavaland shuttle and salvage shuttle console screen overlay sprites.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Previous all three (cargo shuttle included) shared the same overlay sprite and telling them apart at a glance was impossible. Now, you can!

## Technical details
<!-- Summary of code changes for easier review. -->
Just changed the overlay sprite layer names. Didn't even actually add any new sprites.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![SS14 Loader_Ow5HJvwrRY](https://github.com/user-attachments/assets/adcc0456-1472-4fc2-9df9-1d7901c59540)
![SS14 Loader_oQG0EM9nOM](https://github.com/user-attachments/assets/87a80319-f48e-4f82-b418-08742e99c21f)
