### PR TITLE
Air Alarm 'Cycling' Mode Improvements

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
@@ -55,11 +55,11 @@ public sealed partial class AirAlarmWindow : FancyWindow
             {
                 AirAlarmMode.Filtering => "air-alarm-ui-mode-filtering",
                 AirAlarmMode.WideFiltering => "air-alarm-ui-mode-wide-filtering",
+                AirAlarmMode.Cycling => "air-alarm-ui-mode-cycling",
+                AirAlarmMode.WideCycling => "air-alarm-ui-mode-wide-cycling",
                 AirAlarmMode.Fill => "air-alarm-ui-mode-fill",
                 AirAlarmMode.Panic => "air-alarm-ui-mode-panic",
                 AirAlarmMode.None => "air-alarm-ui-mode-none",
-                AirAlarmMode.Cycling => "air-alarm-ui-mode-cycling",
-                AirAlarmMode.WideCycling => "air-alarm-ui-mode-wide-cycling",
                 _ => "error",
             };
             _modes.AddItem(Loc.GetString(text));

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmModes.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmModes.cs
@@ -68,11 +68,11 @@ public sealed class AirAlarmModeFactory
         {
             AirAlarmMode.Filtering => _filterMode,
             AirAlarmMode.WideFiltering => _wideFilterMode,
+            AirAlarmMode.Cycling => _cyclingMode,
+            AirAlarmMode.WideCycling => _wideCyclingMode,
             AirAlarmMode.Fill => _fillMode,
             AirAlarmMode.Panic => _panicMode,
             AirAlarmMode.None => _noneMode,
-            AirAlarmMode.Cycling => _cyclingMode,
-            AirAlarmMode.WideCycling => _wideCyclingMode,
             _ => null
         };
     }
@@ -155,6 +155,48 @@ public sealed class AirAlarmWideFilterMode : AirAlarmModeExecutor
     }
 }
 
+public sealed class AirAlarmCyclingMode : AirAlarmModeExecutor
+{
+    public override void Execute(EntityUid uid)
+    {
+        if (!EntityManager.TryGetComponent(uid, out AirAlarmComponent? alarm))
+            return;
+
+        foreach (var (addr, device) in alarm.VentData)
+        {
+            AirAlarmSystem.SetData(uid, addr, GasVentPumpData.FillModePreset);
+        }
+
+        foreach (var (addr, device) in alarm.ScrubberData)
+        {
+            var data = GasVentScrubberData.PanicModePreset;
+            data.WideNet = false;
+            AirAlarmSystem.SetData(uid, addr, data);
+        }
+    }
+}
+
+public sealed class AirAlarmWideCyclingMode : AirAlarmModeExecutor
+{
+    public override void Execute(EntityUid uid)
+    {
+        if (!EntityManager.TryGetComponent(uid, out AirAlarmComponent? alarm))
+            return;
+
+        foreach (var (addr, device) in alarm.VentData)
+        {
+            AirAlarmSystem.SetData(uid, addr, GasVentPumpData.FillModePreset);
+        }
+
+        foreach (var (addr, device) in alarm.ScrubberData)
+        {
+            var data = GasVentScrubberData.PanicModePreset;
+            data.WideNet = true;
+            AirAlarmSystem.SetData(uid, addr, data);
+        }
+    }
+}
+
 public sealed class AirAlarmPanicMode : AirAlarmModeExecutor
 {
     public override void Execute(EntityUid uid)
@@ -189,48 +231,6 @@ public sealed class AirAlarmFillMode : AirAlarmModeExecutor
         foreach (var (addr, device) in alarm.ScrubberData)
         {
             AirAlarmSystem.SetData(uid, addr, GasVentScrubberData.FillModePreset);
-        }
-    }
-}
-
-public sealed class AirAlarmCyclingMode : AirAlarmModeExecutor
-{
-    public override void Execute(EntityUid uid)
-    {
-        if (!EntityManager.TryGetComponent(uid, out AirAlarmComponent? alarm))
-            return;
-
-        foreach (var (addr, device) in alarm.VentData)
-        {
-            AirAlarmSystem.SetData(uid, addr, GasVentPumpData.FilterModePreset);
-        }
-
-        foreach (var (addr, device) in alarm.ScrubberData)
-        {
-            var data = GasVentScrubberData.PanicModePreset;
-            data.WideNet = false;
-            AirAlarmSystem.SetData(uid, addr, data);
-        }
-    }
-}
-
-public sealed class AirAlarmWideCyclingMode : AirAlarmModeExecutor
-{
-    public override void Execute(EntityUid uid)
-    {
-        if (!EntityManager.TryGetComponent(uid, out AirAlarmComponent? alarm))
-            return;
-
-        foreach (var (addr, device) in alarm.VentData)
-        {
-            AirAlarmSystem.SetData(uid, addr, GasVentPumpData.FilterModePreset);
-        }
-
-        foreach (var (addr, device) in alarm.ScrubberData)
-        {
-            var data = GasVentScrubberData.PanicModePreset;
-            data.WideNet = true;
-            AirAlarmSystem.SetData(uid, addr, data);
         }
     }
 }

--- a/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
+++ b/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
@@ -14,10 +14,10 @@ public enum AirAlarmMode
     None,
     Filtering,
     WideFiltering,
-    Fill,
-    Panic,
     Cycling,
     WideCycling,
+    Fill,
+    Panic,
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
'Cycling' modes now make distro air vents work the same was as 'Fill' mode - 4500kPa and bypass pressure locks - in order to be more effective against the scrubbers' siphon mode.

Also moved the Cycling options up in the modes list UI to make them more appealing as an option.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Cycling was pretty effective at 'refreshing' a room of air to help stabilise temperatures but previously air vents only output at normal filtering rates, which often meant that the scrubbers would space the room faster than the distro could replenish the air. This was mitigated by manually setting air vents to 4500kPa outward pressure but was tedious. This automates that and also ensures that the air vents don't totally pressure lock too.

The UI ordering is to help atmos techs discover and understand the use of this mode to make fixing frezon/nitrium leak after-effects faster.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed the air vent mode from filter to fill in the cycling presets and moved the order of options in the shared component.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![SS14 Loader_jY22WDtY2H](https://github.com/user-attachments/assets/323a8c66-6d0c-493d-ae42-9937d3c947b4)
