### PR TITLE
Allow Salvage Shuttle to FTL to Lavaland / Remove Lavaland Transport / Adjust Lavaland Outpost / Mapping Updates

### DIFF
--- a/Resources/Locale/en-US/deltav/shuttles/docking-console.ftl
+++ b/Resources/Locale/en-US/deltav/shuttles/docking-console.ftl
@@ -2,7 +2,7 @@ docking-console-no-shuttle = No Shuttle Detected
 docking-console-ftl = FTL
 docking-console-call = Call shuttle
 
-mining-console-window-title = Lavaland Transport Console
+mining-console-window-title = Lavaland FTL Console
 
 shuttle-destination-lavaland = Lavaland
 shuttle-destination-glacier-surface = Glacier Surface

--- a/Resources/Maps/Shuttles/mining.yml
+++ b/Resources/Maps/Shuttles/mining.yml
@@ -57,6 +57,9 @@ entities:
     - type: Fixtures
       fixtures: {}
     - type: SalvageShuttle
+    - type: MiningShuttle # ShibaStation - make the salv shuttle lavaland-able.
+    - type: DockingShuttle # ShibaStation - make the salv shuttle attempt to dock to the station after FTL (and dock at Lavaland hopefully)
+      destinations: []
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg

--- a/Resources/Maps/_Lavaland/mining.yml
+++ b/Resources/Maps/_Lavaland/mining.yml
@@ -59,7 +59,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-    - type: MiningShuttle
+    # - type: MiningShuttle # ShibaStation - hopefully prevents the console from trying to load this grid
     - type: DockingShuttle
       destinations: []
     - type: ProtectedGrid

--- a/Resources/Prototypes/_Lavaland/Entities/Structures/computers.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Structures/computers.yml
@@ -34,8 +34,8 @@
 - type: entity
   parent: BaseComputerDocking
   id: ComputerShuttleMiningLavaland
-  name: lavaland transport console
-  description: Used to pilot the lavaland transport to and from the lavaland base.
+  name: lavaland FTL console
+  description: Used to directly pilot the Salvage Shuttle to and from the lavaland base.
   components:
   - type: DockingConsole
     windowTitle: mining-console-window-title


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed the Lavaland Mining Shuttle.
Enable the Salvage Shuttle to FTL to/from Lavaland.
Modify the Lavaland Outpost to fit the Salvage Shuttle at dock (and a few other adjustments.
Update the 'Shiba Seven' maps in rotation to better accommodate the Salvage Shuttle, as well as remove the Lavaland FTL Console from stations and use `migration.yml` to replace any existing Mining Shuttle (Filled) Airlocks with an alternative to ensure the Lavaland Mining Shuttle never spawns.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The Lavaland Transport Shuttle is broken and Goob currently has no intention of fixing it currently. I've spend nearly a week diagnosing the problem and while I know _why_ it sometimes doesn't dock, I don't know the _cause_ of the why and my skill issue refuses to become a skill solution, so I'm attempting a different approach.

Since unlike Goob we reinstated the Salvage Shuttle, VGroid, Asteroids, etc, Cargo/Salv now has THREE shuttles of their own which is ludicrous. Plus trying to accommodate the Lavaland Shuttle **and** the Salvage Shuttle was already a nightmare.

Removing the Lavaland Transport, which is just a glorified teleporter since the shuttle is un-pilotable (one of the major selling points of SS14 just entirely removed, good going Goob), and integrating its functionality with the Salvage Shuttle that we preserved just makes more sense the more it's considered. Salvagers on Lavaland really should be going out in at least a team of two and generally players prefer to go there than the VGroid or asteroid mine anyway, although I should still argue they should grind some Mining Points _first_ using the safer options before getting ashed on Lavaland at round start.

The intention is to try to get the Salvage Shuttle to autodock with the station on arrival from Lavaland as the Lavaland Shuttle did, however as I'm convinced the unique Lavaland docking code is somewhat responsible for the inconsistency, I fully expect that the Salv Shuttle will also fail to dock entirely and arrive at some random location in space. **However** since the Salvage Shuttle is actually PILOTABLE, _at least_ Salvies can then fly the rest of the way back home themselves. This eliminates the biggest issue with the Lavaland Transport and will FINALLY give me reprieve from the constant ahelps and bitching and moaning.

## Technical details
<!-- Summary of code changes for easier review. -->
**To Do**
- [ ] Remove the Lavaland Mining Shuttle (not actual remove files, just disable it from spawning)
- [ ] Make Salvage Shuttle capable of FTLing to Lavaland and back
- [ ] Remap the Lavaland Outpost to fit the Salvage Shuttle (it's bigger)

**Remap the Shiba Seven maps for better Salvage Shuttle Docking**
- [ ] Amber
- [ ] Atlas
- [ ] Cluster
- [ ] Elkridge
- [ ] Omega
- [ ] Packed
- [ ] Saltern
