### PR TITLE
Felind and Oni Tag Fix 

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -37,13 +37,6 @@
         - MobLayer
   - type: Stamina
     critThreshold: 115
-  - type: Tag
-    tags:
-    - Oni
-    - CanPilot # ShibaStation
-    - FootstepSound # ShibaStation
-    - DoorBumpOpener # ShibaStation
-    - AnomalyHost # ShibaStation
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -40,6 +40,10 @@
   - type: Tag
     tags:
     - Oni
+    - CanPilot # ShibaStation
+    - FootstepSound # ShibaStation
+    - DoorBumpOpener # ShibaStation
+    - AnomalyHost # ShibaStation
 
 - type: entity
   save: false
@@ -48,3 +52,4 @@
   id: MobOniDummy
   categories: [ HideSpawnMenu ]
   description: A dummy oni meant to be used in character setup.
+

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -45,4 +45,3 @@
   id: MobOniDummy
   categories: [ HideSpawnMenu ]
   description: A dummy oni meant to be used in character setup.
-

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -72,6 +72,7 @@
     - FootstepSound
     - DoorBumpOpener
     - FelinidEmotes
+    - AnomalyHost # ShibaStation
   - type: FootPrints # WD EDIT
   - type: FelinidAccent # ShibaStation - hehe funne cringe cat accent :D
 

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
@@ -4,10 +4,6 @@
   id: Terminus
   description: An advanced weapon crafted specifically for an oni. Capable of firing a spread of disabler shots from its tip.
   components:
-  - type: RestrictedMelee
-    whitelist:
-      components:
-        - Oni
   - type: Sprite
     sprite: /Textures/_EinsteinEngines/Objects/Weapons/Melee/terminus.rsi
     state: icon

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Objects/Weapons/Melee/terminus.yml
@@ -4,6 +4,10 @@
   id: Terminus
   description: An advanced weapon crafted specifically for an oni. Capable of firing a spread of disabler shots from its tip.
   components:
+  - type: RestrictedMelee
+    whitelist:
+      components:
+        - Oni
   - type: Sprite
     sprite: /Textures/_EinsteinEngines/Objects/Weapons/Melee/terminus.rsi
     state: icon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the `AnomalyHost` tag to felinid.yml. Porting some fixes for Oni.yml 

## Why / Balance

The `AnomalyHost` tag was added to Felinids to enable them to host anomalies. This tag appears to have been absent for so long that it is unclear whether its omission was intentional. Please let me know if any changes are required.

The Oni related changes address a recent commit involving the addition of the Oni tag. When this tag was applied to the Oni prototype, it stopped inheriting tags from its parent. Consequently, it now only has the tag 'Oni' and is missing `CanPilot`, `FootstepSound`, `DoorBumpOpener`, and `AnomalyHost` tags. These changes restore those tags and ensure the introduced weapon in the recent merged pull request works as intended. 

[From this merge](https://github.com/Goob-Station/Goob-Station/pull/1948)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->



**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Felinids are no longer immune to infectious anomalies; this is a nerf. :(
- fix: Onis can once again open doors on collision, pilot shuttles, make footstep sounds, and be infected by anomalies
-->
