### PR TITLE
Rolly chair spawners and mapping

### DIFF
--- a/Resources/Maps/_ShibaStation/amber.yml
+++ b/Resources/Maps/_ShibaStation/amber.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/12/2025 14:42:49
-  entityCount: 23489
+  time: 03/13/2025 12:34:24
+  entityCount: 23515
 maps:
 - 1
 grids:
@@ -69418,14 +69418,11 @@ entities:
       linearDamping: 0
 - proto: CrateNPCHamlet
   entities:
-  - uid: 20764
+  - uid: 342
     components:
     - type: Transform
-      pos: -16.5,-50.654945
+      pos: -14.5,-51.5
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: CrateSecurityTrackingMindshieldImplants
   entities:
   - uid: 4184
@@ -140826,6 +140823,137 @@ entities:
     - type: Transform
       pos: -21.5,-4.5
       parent: 2
+- proto: SpawnVehicleJanicart
+  entities:
+  - uid: 7570
+    components:
+    - type: Transform
+      pos: 28.5,3.5
+      parent: 2
+- proto: SpawnVehicleOfficeChairDark
+  entities:
+  - uid: 271
+    components:
+    - type: Transform
+      pos: -13.5,-46.5
+      parent: 2
+  - uid: 463
+    components:
+    - type: Transform
+      pos: -25.5,-51.5
+      parent: 2
+  - uid: 858
+    components:
+    - type: Transform
+      pos: -20.5,-44.5
+      parent: 2
+  - uid: 914
+    components:
+    - type: Transform
+      pos: -19.5,-44.5
+      parent: 2
+  - uid: 2878
+    components:
+    - type: Transform
+      pos: -20.5,-3.5
+      parent: 2
+  - uid: 3438
+    components:
+    - type: Transform
+      pos: -21.5,11.5
+      parent: 2
+  - uid: 3606
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 2
+  - uid: 4357
+    components:
+    - type: Transform
+      pos: 38.5,2.5
+      parent: 2
+  - uid: 4498
+    components:
+    - type: Transform
+      pos: 27.5,10.5
+      parent: 2
+  - uid: 6163
+    components:
+    - type: Transform
+      pos: 21.5,-37.5
+      parent: 2
+  - uid: 6364
+    components:
+    - type: Transform
+      pos: 21.5,-40.5
+      parent: 2
+  - uid: 6601
+    components:
+    - type: Transform
+      pos: 22.5,-43.5
+      parent: 2
+  - uid: 7418
+    components:
+    - type: Transform
+      pos: -13.5,-14.5
+      parent: 2
+  - uid: 7532
+    components:
+    - type: Transform
+      pos: -8.5,-26.5
+      parent: 2
+- proto: SpawnVehicleOfficeChairLight
+  entities:
+  - uid: 985
+    components:
+    - type: Transform
+      pos: -28.5,-34.5
+      parent: 2
+  - uid: 2229
+    components:
+    - type: Transform
+      pos: -28.5,-25.5
+      parent: 2
+  - uid: 2536
+    components:
+    - type: Transform
+      pos: -48.5,-21.5
+      parent: 2
+  - uid: 3856
+    components:
+    - type: Transform
+      pos: 16.5,14.5
+      parent: 2
+  - uid: 4190
+    components:
+    - type: Transform
+      pos: 28.5,4.5
+      parent: 2
+  - uid: 4582
+    components:
+    - type: Transform
+      pos: 21.5,3.5
+      parent: 2
+  - uid: 5153
+    components:
+    - type: Transform
+      pos: 19.5,-24.5
+      parent: 2
+  - uid: 5740
+    components:
+    - type: Transform
+      pos: 36.5,-40.5
+      parent: 2
+  - uid: 6063
+    components:
+    - type: Transform
+      pos: 31.5,-34.5
+      parent: 2
+  - uid: 7557
+    components:
+    - type: Transform
+      pos: -49.5,-45.5
+      parent: 2
 - proto: SpawnVendingMachineRestockFoodDrink
   entities:
   - uid: 20685
@@ -146765,6 +146893,13 @@ entities:
       angularDamping: 0
       linearDamping: 0
       canCollide: False
+- proto: VehicleKeyJanicart
+  entities:
+  - uid: 7675
+    components:
+    - type: Transform
+      pos: 28.49301,2.85808
+      parent: 2
 - proto: VendingBarDrobe
   entities:
   - uid: 21407

--- a/Resources/Maps/_ShibaStation/cluster.yml
+++ b/Resources/Maps/_ShibaStation/cluster.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/12/2025 15:15:50
-  entityCount: 12836
+  time: 03/13/2025 12:40:12
+  entityCount: 12861
 maps:
 - 1
 grids:
@@ -6207,7 +6207,7 @@ entities:
       pos: 30.5,-11.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -5443.2783
+      secondsUntilStateChange: -5636.116
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -68846,6 +68846,135 @@ entities:
     components:
     - type: Transform
       pos: 15.5,-1.5
+      parent: 2
+- proto: SpawnVehicleOfficeChairDark
+  entities:
+  - uid: 4044
+    components:
+    - type: Transform
+      pos: 12.5,-10.5
+      parent: 2
+  - uid: 4045
+    components:
+    - type: Transform
+      pos: 8.5,-21.5
+      parent: 2
+  - uid: 4046
+    components:
+    - type: Transform
+      pos: 5.5,-16.5
+      parent: 2
+  - uid: 4047
+    components:
+    - type: Transform
+      pos: 17.5,-14.5
+      parent: 2
+  - uid: 4048
+    components:
+    - type: Transform
+      pos: 26.5,5.5
+      parent: 2
+  - uid: 4049
+    components:
+    - type: Transform
+      pos: 14.5,13.5
+      parent: 2
+  - uid: 4050
+    components:
+    - type: Transform
+      pos: 28.5,13.5
+      parent: 2
+  - uid: 4051
+    components:
+    - type: Transform
+      pos: 28.5,17.5
+      parent: 2
+  - uid: 4052
+    components:
+    - type: Transform
+      pos: -5.5,30.5
+      parent: 2
+  - uid: 4053
+    components:
+    - type: Transform
+      pos: -4.5,30.5
+      parent: 2
+  - uid: 4054
+    components:
+    - type: Transform
+      pos: -2.5,31.5
+      parent: 2
+  - uid: 4055
+    components:
+    - type: Transform
+      pos: -1.5,31.5
+      parent: 2
+  - uid: 4056
+    components:
+    - type: Transform
+      pos: 0.5,30.5
+      parent: 2
+  - uid: 4057
+    components:
+    - type: Transform
+      pos: 1.5,30.5
+      parent: 2
+  - uid: 4058
+    components:
+    - type: Transform
+      pos: 4.5,28.5
+      parent: 2
+  - uid: 4059
+    components:
+    - type: Transform
+      pos: -8.5,29.5
+      parent: 2
+  - uid: 4060
+    components:
+    - type: Transform
+      pos: -8.5,28.5
+      parent: 2
+  - uid: 4061
+    components:
+    - type: Transform
+      pos: -8.5,27.5
+      parent: 2
+  - uid: 4062
+    components:
+    - type: Transform
+      pos: -10.5,29.5
+      parent: 2
+  - uid: 4063
+    components:
+    - type: Transform
+      pos: -10.5,28.5
+      parent: 2
+  - uid: 4064
+    components:
+    - type: Transform
+      pos: -10.5,27.5
+      parent: 2
+- proto: SpawnVehicleOfficeChairLight
+  entities:
+  - uid: 4041
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 2
+  - uid: 4042
+    components:
+    - type: Transform
+      pos: -9.5,13.5
+      parent: 2
+  - uid: 4043
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 2
+  - uid: 4065
+    components:
+    - type: Transform
+      pos: -19.5,14.5
       parent: 2
 - proto: SpawnVehicleSecway
   entities:

--- a/Resources/Maps/_ShibaStation/omega.yml
+++ b/Resources/Maps/_ShibaStation/omega.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/12/2025 14:43:25
-  entityCount: 13861
+  time: 03/13/2025 12:43:51
+  entityCount: 13887
 maps:
 - 473
 grids:
@@ -74242,6 +74242,140 @@ entities:
     components:
     - type: Transform
       pos: -34.5,15.5
+      parent: 4812
+- proto: SpawnVehicleOfficeChairDark
+  entities:
+  - uid: 2686
+    components:
+    - type: Transform
+      pos: -3.5,-27.5
+      parent: 4812
+  - uid: 3704
+    components:
+    - type: Transform
+      pos: -31.5,-19.5
+      parent: 4812
+  - uid: 4569
+    components:
+    - type: Transform
+      pos: -30.5,1.5
+      parent: 4812
+  - uid: 4595
+    components:
+    - type: Transform
+      pos: -30.5,-5.5
+      parent: 4812
+  - uid: 4973
+    components:
+    - type: Transform
+      pos: -25.5,11.5
+      parent: 4812
+  - uid: 5371
+    components:
+    - type: Transform
+      pos: -8.5,33.5
+      parent: 4812
+  - uid: 6179
+    components:
+    - type: Transform
+      pos: -7.5,33.5
+      parent: 4812
+  - uid: 6180
+    components:
+    - type: Transform
+      pos: -5.5,34.5
+      parent: 4812
+  - uid: 6216
+    components:
+    - type: Transform
+      pos: -4.5,34.5
+      parent: 4812
+  - uid: 6288
+    components:
+    - type: Transform
+      pos: -0.5,34.5
+      parent: 4812
+  - uid: 6320
+    components:
+    - type: Transform
+      pos: 0.5,34.5
+      parent: 4812
+  - uid: 6344
+    components:
+    - type: Transform
+      pos: 2.5,33.5
+      parent: 4812
+  - uid: 6475
+    components:
+    - type: Transform
+      pos: 3.5,33.5
+      parent: 4812
+  - uid: 6619
+    components:
+    - type: Transform
+      pos: 9.5,24.5
+      parent: 4812
+  - uid: 6620
+    components:
+    - type: Transform
+      pos: 28.5,2.5
+      parent: 4812
+  - uid: 7037
+    components:
+    - type: Transform
+      pos: 15.5,17.5
+      parent: 4812
+  - uid: 7038
+    components:
+    - type: Transform
+      pos: 17.5,30.5
+      parent: 4812
+  - uid: 7071
+    components:
+    - type: Transform
+      pos: -33.5,15.5
+      parent: 4812
+  - uid: 7072
+    components:
+    - type: Transform
+      pos: -49.5,-7.5
+      parent: 4812
+  - uid: 7073
+    components:
+    - type: Transform
+      pos: 19.5,-15.5
+      parent: 4812
+- proto: SpawnVehicleOfficeChairLight
+  entities:
+  - uid: 2508
+    components:
+    - type: Transform
+      pos: 3.5,-15.5
+      parent: 4812
+  - uid: 2665
+    components:
+    - type: Transform
+      pos: 23.5,-26.5
+      parent: 4812
+  - uid: 2666
+    components:
+    - type: Transform
+      pos: 25.5,-18.5
+      parent: 4812
+  - uid: 2667
+    components:
+    - type: Transform
+      pos: 3.5,-23.5
+      parent: 4812
+  - uid: 3237
+    components:
+    - type: Transform
+      pos: -9.5,-25.5
+      parent: 4812
+  - uid: 3238
+    components:
+    - type: Transform
+      pos: -11.5,-18.5
       parent: 4812
 - proto: Spoon
   entities:

--- a/Resources/Maps/_ShibaStation/packed.yml
+++ b/Resources/Maps/_ShibaStation/packed.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/12/2025 14:47:05
-  entityCount: 15335
+  time: 03/13/2025 12:47:32
+  entityCount: 15356
 maps:
 - 126
 grids:
@@ -79883,6 +79883,115 @@ entities:
     components:
     - type: Transform
       pos: 6.5,-5.5
+      parent: 2
+- proto: SpawnVehicleOfficeChairDark
+  entities:
+  - uid: 311
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 16.5,-3.5
+      parent: 2
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 29.5,25.5
+      parent: 2
+  - uid: 579
+    components:
+    - type: Transform
+      pos: 20.5,45.5
+      parent: 2
+  - uid: 683
+    components:
+    - type: Transform
+      pos: 23.5,47.5
+      parent: 2
+  - uid: 684
+    components:
+    - type: Transform
+      pos: 24.5,47.5
+      parent: 2
+  - uid: 940
+    components:
+    - type: Transform
+      pos: 31.5,47.5
+      parent: 2
+  - uid: 1010
+    components:
+    - type: Transform
+      pos: 7.5,18.5
+      parent: 2
+  - uid: 1852
+    components:
+    - type: Transform
+      pos: 20.5,22.5
+      parent: 2
+  - uid: 2318
+    components:
+    - type: Transform
+      pos: 37.5,18.5
+      parent: 2
+  - uid: 2727
+    components:
+    - type: Transform
+      pos: 42.5,20.5
+      parent: 2
+  - uid: 4999
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 2
+  - uid: 5000
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 2
+  - uid: 5001
+    components:
+    - type: Transform
+      pos: 11.5,-34.5
+      parent: 2
+- proto: SpawnVehicleOfficeChairLight
+  entities:
+  - uid: 2480
+    components:
+    - type: Transform
+      pos: 49.5,18.5
+      parent: 2
+  - uid: 2489
+    components:
+    - type: Transform
+      pos: 62.5,9.5
+      parent: 2
+  - uid: 2632
+    components:
+    - type: Transform
+      pos: 44.5,3.5
+      parent: 2
+  - uid: 2678
+    components:
+    - type: Transform
+      pos: 50.5,2.5
+      parent: 2
+  - uid: 2724
+    components:
+    - type: Transform
+      pos: 50.5,-4.5
+      parent: 2
+  - uid: 2725
+    components:
+    - type: Transform
+      pos: 55.5,-11.5
+      parent: 2
+  - uid: 2726
+    components:
+    - type: Transform
+      pos: 61.5,-11.5
       parent: 2
 - proto: SprayBottle
   entities:

--- a/Resources/Prototypes/_ShibaStation/Entities/Markers/Spawners/vehicles.yml
+++ b/Resources/Prototypes/_ShibaStation/Entities/Markers/Spawners/vehicles.yml
@@ -1,0 +1,27 @@
+- type: entity
+  name: Dark Office Chair Spawner
+  id: SpawnVehicleOfficeChairDark
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+      - sprite: Structures/Furniture/chairs.rsi
+        state: office-dark
+  - type: ConditionalSpawner
+    prototypes:
+      - ChairOfficeDark
+
+- type: entity
+  name: White Office Chair Spawner
+  id: SpawnVehicleOfficeChairLight
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+      - sprite: Structures/Furniture/chairs.rsi
+        state: office-white
+  - type: ConditionalSpawner
+    prototypes:
+      - ChairOfficeLight


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added office chair spawn markers for mapping and mapped some to maps that had lost their office chairs.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Vehicles don't get saved when maps are saved, and now that office chairs are vehicles, they'll start disappearing when maps are edited and saved after the fact. 

We lost chairs on four maps after I modified them with some fixes, so I made the office chair spawners and mapped them so they'll spawn on those maps again.

You can't rotate spawners, though - so all office chair spawn facing south, which is lame, but your average person won't care.

## Technical details
<!-- Summary of code changes for easier review. -->
yaml and mapping
