### PR TITLE
Allow Shutter and Blast Door Frames to Be Rotated During Construction

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -100,8 +100,6 @@
         - HighImpassable
         layer:
         - HighImpassable
-  - type: Transform
-    noRot: false #ShibaStation
   - type: Rotatable #ShibaStation
   - type: Construction
     graph: BlastDoor

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -101,7 +101,8 @@
         layer:
         - HighImpassable
   - type: Transform
-    noRot: true
+    noRot: false #ShibaStation
+  - type: Rotatable #ShibaStation
   - type: Construction
     graph: BlastDoor
     node: frame1

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -236,6 +236,4 @@
         - HighImpassable
         layer:
         - HighImpassable
-  - type: Transform
-    noRot: false #ShibaStation - Prevents rotation being reset to Angle.Zero by TransformComponent and being locked.
-  - type: Rotatable #ShibaStation - Allows for rotation during construction.
+  - type: Rotatable #ShibaStation

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -237,4 +237,4 @@
         layer:
         - HighImpassable
   - type: Transform
-    noRot: true
+    noRot: false #ShibaStation

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -237,4 +237,5 @@
         layer:
         - HighImpassable
   - type: Transform
-    noRot: false #ShibaStation
+    noRot: false #ShibaStation - Prevents rotation being reset to Angle.Zero by TransformComponent and being locked.
+  - type: Rotatable #ShibaStation - Allows for rotation during construction.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

I've removed the `NoRot` property from `ShutterFrame` and `BlastDoorFrame`. Without this property, the `Type: Transform` component is unnecessary, as it is inherited from the parent `BaseStructureDynamic`, so I’ve removed that as well.  

Additionally, I have assigned both of them the `type: Rotatable`, which allows them to be rotated. This applies only during the construction stage; once completed, none of these changes will be in effect.  

The `NoRot` property ensured that the Frames could **_not_** be rotated and defaulted to an `Angle.Zero` rotation. With this change, both shutters and blast door frames will retain the rotation of their construction ghosts as well. 

## Why / Balance
It was suggested on Discord that we should be able to place shutters that do not only face south, and I agree. I also thought it would be nice to apply the same change to blast doors. While airlocks rotate with your camera, shutters and blast doors do not. Allowing them to have custom rotations would be a nice improvement.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- Tweak: Shutters and blast doors are now rotatable during construction.
