### PR TITLE
Add basic parts to some techfabs

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -551,6 +551,8 @@
     - MedicalBoardsStatic
     - MedicalBoardsStaticGoob
     - PowerCellsStatic
+    # Shibastation Packs
+    - MedicalPartsStatic
     dynamicPacks:
     - Chemistry
     # Goobstation Packs

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
@@ -86,6 +86,8 @@
     - CablesStatic
     - PowerCellsStatic
     - MiningToolsStatic
+    #Shibastation Packs
+    - CargoPartsStatic
     dynamicPacks:
     - AdvancedTools
     - Mining
@@ -212,6 +214,8 @@
     - PowerCellsStatic
     - LatheMiscStatic
     - ChemistryStatic
+    # Shibastation Packs
+    - ServicePartsStatic
     dynamicPacks:
     - Janitor
     - Instruments

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/cargo.yml
@@ -6,6 +6,13 @@
   - FultonBeacon
   - OreBag
 
+- type: latheRecipePack
+  id: CargoPartsStatic
+  recipes:
+  - MicroManipulatorStockPart
+  - MatterBinStockPart
+  - CapacitorStockPart
+
 ## Dynamic
 - type: latheRecipePack
   id: MiningWeapons

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/medical.yml
@@ -31,6 +31,14 @@
   recipes:
   - VehicleHoverchairSci
 
+- type: latheRecipePack
+  id: MedicalPartsStatic
+  recipes:
+  - MicroManipulatorStockPart
+  - MatterBinStockPart
+  - CapacitorStockPart
+  - CableStack
+
 ## Dynamic
 - type: latheRecipePack
   id: MedicalSurgery

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/service.yml
@@ -2,3 +2,11 @@
   id: ServiceWeapons
   recipes:
   - WeaponLaserSvalinn
+
+- type: latheRecipePack
+  id: ServicePartsStatic
+  recipes:
+  - MicroManipulatorStockPart
+  - MatterBinStockPart
+  - CapacitorStockPart
+  - CableStack


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added Manipulators, Matter bins, Capacitors and LV cables to techfabs with printable machine circuit boards

## Why / Balance
To allow departments to assemble there machine boards without having to find a separate lathe.

## Technical details
Added lathe recipe packs to cargo, medical and service techfabs.
Updated the goob and wizden pack lists for each techfab.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added parts for machine construction to some techfabs.
