### PR TITLE
Animal organs are trash (and mouse stomachs are edible)

### DIFF
--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -115,22 +115,19 @@
 - type: entity
   id: OrganMouseStomach
   parent: OrganAnimalStomach
-  name: stomach
-  categories: [ HideSpawnMenu ]
+  suffix: "mouse"
   components:
   - type: SolutionContainerManager
     solutions:
       stomach:
-        maxVol: 30
-  - type: Item
-    size: Small
-    heldPrefix: stomach
-  - type: Tag # tags are dumb and I think this was making them unedible.
-    tags:
-    - Meat
-    - Organ
-    - Stomach
-    - Trash
+        maxVol: 50
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5
+  - type: Sprite
+    state: stomach
 
 - type: entity
   id: OrganAnimalLiver

--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -23,6 +23,7 @@
     tags:
     - Meat
     - Organ
+    - Trash
 
 - type: entity
   id: BaseAnimalOrgan
@@ -70,6 +71,7 @@
     - Meat
     - Organ
     - Lungs
+    - Trash
   - type: Item
     size: Small
     heldPrefix: lungs
@@ -105,6 +107,7 @@
     - Meat
     - Organ
     - Stomach
+    - Trash
   - type: Item
     size: Small
     heldPrefix: stomach
@@ -122,6 +125,12 @@
   - type: Item
     size: Small
     heldPrefix: stomach
+  - type: Tag # tags are dumb and I think this was making them unedible.
+    tags:
+    - Meat
+    - Organ
+    - Stomach
+    - Trash
 
 - type: entity
   id: OrganAnimalLiver
@@ -145,6 +154,7 @@
     - Meat
     - Organ
     - Liver
+    - Trash
   - type: Item
     size: Small
     heldPrefix: liver
@@ -172,6 +182,7 @@
     - Meat
     - Organ
     - Heart
+    - Trash
   - type: Item
     size: Small
     heldPrefix: heart
@@ -197,6 +208,7 @@
     - Meat
     - Organ
     - Kidneys
+    - Trash
   - type: Item
     size: Small
     heldPrefix: kidneys


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the trash tag to animal organs and made mouse stomachs edible

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's a pain in the arse to have to manually pick up each organ to put it in the recycler and also mice stomachs were inedible for some reason?

## Technical details
<!-- Summary of code changes for easier review. -->
Just made the mouse stomachs be the same as rat stomachs, and added the trash tag to animal organ prototypes. All yaml.