### PR TITLE
Various antag/event tweaks to make them more common

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -161,6 +161,8 @@
     weight: 5
     duration: 1
     minimumPlayers: 10
+    earliestStart: 90 # ShibaStation - First skeleton should spawn late into the shift.
+    reoccurrenceDelay: 60 # ShibaStation - Skeletons now can only happen after 60 minutes since the last one.
     maxOccurrences: 2 # ShibaStation - Capped at 2, we get too many dang skeletons.
   - type: RandomEntityStorageSpawnRule
     prototype: MobSkeletonCloset
@@ -171,9 +173,9 @@
   components:
   - type: StationEvent
     weight: 2
-    earliestStart: 75
+    earliestStart: 135 # ShibaStation - happens later, after the first recall.
     reoccurrenceDelay: 20
-    minimumPlayers: 60
+    minimumPlayers: 16 # ShibaStation - reduced from 20 to 16.
     duration: null
   - type: SpaceSpawnRule
     spawnDistance: 0
@@ -201,9 +203,9 @@
   - type: StationEvent
     weight: 6
     duration: null
-    earliestStart: 45
-    reoccurrenceDelay: 20
-    minimumPlayers: 30
+    earliestStart: 135
+    reoccurrenceDelay: 40
+    minimumPlayers: 16
   - type: SpaceSpawnRule
   - type: AntagLoadProfileRule
     # Goobstation start
@@ -259,8 +261,8 @@
   - type: StationEvent
     weight: 3.5
     duration: 1
-    earliestStart: 30
-    minimumPlayers: 20
+    earliestStart: 90
+    minimumPlayers: 16
   - type: RandomSpawnRule
     prototype: MobRevenant
 
@@ -286,8 +288,8 @@
     endAudio:
       path: /Audio/_ShibaStation/Announcements/gasleak-end.ogg
     weight: 6 # ShibaStation - Reduced from 8 to 6
-    reoccurrenceDelay: 30 # ShibaStation - Gas leaks now can only happen after 30 minutes since the last one.
-    maxOccurrences: 5 # ShibaStation - Gas leaks now can only happen 5 times per round.
+    reoccurrenceDelay: 45 # ShibaStation - Gas leaks now can only happen after 30 minutes since the last one.
+    maxOccurrences: 3 # ShibaStation - Gas leaks now can only happen 3 times per round.
   - type: GasLeakRule
 
 - type: entity
@@ -295,10 +297,11 @@
   parent: BaseStationEventLongDelay
   components:
   - type: StationEvent
-    earliestStart: 15
-    minimumPlayers: 15
+    earliestStart: 30
+    minimumPlayers: 12
     weight: 5 # ShibaStation - Reduced from 7 to 5
     duration: 240
+    maxOccurrences: 5 # ShibaStation - Kudzu growth now can only happen 5 times per round.
   - type: KudzuGrowthRule
 
 - type: entity
@@ -480,8 +483,9 @@
   - type: StationEvent
     earliestStart: 35
     weight: 5.5
-    minimumPlayers: 25
+    minimumPlayers: 18
     duration: 1
+    maxOccurrences: 1 # ShibaStation - Lone nukies now can only happen once per round.
   - type: RuleGrids
   - type: LoadMapRule
     gridPath: /Maps/Shuttles/ShuttleEvent/striker.yml
@@ -563,7 +567,7 @@
   - type: StationEvent
     weight: 8
     reoccurrenceDelay: 20
-    minimumPlayers: 20 # ShibaStation - Ion storms tend to give out free shitter tickets, and at low pop it's cringe. This better meshes with escalating danger in line with population.
+    minimumPlayers: 16 # ShibaStation - Ion storms tend to give out free shitter tickets, and at low pop it's cringe. This better meshes with escalating danger in line with population.
     duration: 1
   - type: IonStormRule
 
@@ -606,8 +610,9 @@
   - type: StationEvent
     weight: 5
     earliestStart: 15
-    reoccurrenceDelay: 20
-    minimumPlayers: 15 # ShibaStation - Increased from 4 to 15
+    reoccurrenceDelay: 40
+    minimumPlayers: 16 # ShibaStation - Increased from 4 to 16
+    maxOccurrences: 2 # ShibaStation - Derelicts now can only happen twice per round.
     duration: null
   - type: SpaceSpawnRule
     spawnDistance: 0

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -20,7 +20,7 @@
     definitions:
     - prefRoles: [ Thief ]
       max: 3
-      playerRatio: 15
+      playerRatio: 5
       lateJoinAdditional: true
       allowNonHumans: true
       multiAntagSetting: NotExclusive

--- a/Resources/Prototypes/GameRules/random_sentience.yml
+++ b/Resources/Prototypes/GameRules/random_sentience.yml
@@ -5,6 +5,7 @@
   - type: StationEvent
     weight: 6
     duration: 1
+    earliestStart: 30 # ShibaStation
     maxOccurrences: 1 # this event has diminishing returns on interesting-ness, so we cap it
     startAudio:
       path: /Audio/_ShibaStation/Announcements/sentience-event.ogg

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -143,7 +143,7 @@
       fallbackRoles: [ NukeopsCommander, NukeopsMedic ]
       spawnerPrototype: SpawnPointNukeopsOperative
       max: 10 # Goobstation / 古布空间站 - 没有限制的核特工
-      playerRatio: 16 # Goobstation
+      playerRatio: 5 # Goobstation
       startingGear: SyndicateOperativeGearFull
       unequipOldGear: true
       roleLoadout:
@@ -215,7 +215,7 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 16
     cancelPresetOnTooFewPlayers: true # ShibaStation
   - type: RevolutionaryRule
   - type: AntagSelection
@@ -223,7 +223,7 @@
     definitions:
     - prefRoles: [ HeadRev ]
       max: 3
-      playerRatio: 15
+      playerRatio: 10
       briefing:
         text: head-rev-role-greeting
         color: CornflowerBlue

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -29,14 +29,14 @@
   id: CalmTraitor # For Dual Antag Gamemodes
   components:
   - type: GameRule
-    minPlayers: 30
+    minPlayers: 20
     cancelPresetOnTooFewPlayers: true # ShibaStation
   - type: AntagSelection
     selectionTime: BeforeJobs
     definitions:
     - prefRoles: [ Traitor ]
       max: 5
-      playerRatio: 15
+      playerRatio: 10
       blacklist:
         components:
         - AntagImmune
@@ -53,7 +53,7 @@
   id: CalmLing # For Dual Antag Gamemodes
   components:
   - type: GameRule
-    minPlayers: 30
+    minPlayers: 20
     cancelPresetOnTooFewPlayers: true # ShibaStation
   - type: AntagSelection
     selectionTime: BeforeJobs
@@ -61,7 +61,7 @@
     definitions:
     - prefRoles: [ Changeling ]
       max: 2
-      playerRatio: 15
+      playerRatio: 10
       lateJoinAdditional: true
       mindRoles:
       - MindRoleTraitor
@@ -74,7 +74,7 @@
   id: Calmops # For Dual Antag Gamemodes
   components:
   - type: GameRule
-    minPlayers: 30
+    minPlayers: 20
     cancelPresetOnTooFewPlayers: true # ShibaStation
   - type: LoadMapRule
     mapPath: /Maps/_Goobstation/Nonstations/nukieplanet.yml
@@ -84,7 +84,7 @@
     - prefRoles: [ NukeopsCommander ]
       fallbackRoles: [ Nukeops, NukeopsMedic ]
       spawnerPrototype: SpawnPointNukeopsCommander
-      playerRatio: 15
+      playerRatio: 10
       startingGear: SyndicateCommanderGearFull
       unequipOldGear: true
       components:
@@ -101,7 +101,7 @@
     - prefRoles: [ NukeopsMedic ]
       fallbackRoles: [ Nukeops, NukeopsCommander ]
       spawnerPrototype: SpawnPointNukeopsMedic
-      playerRatio: 15
+      playerRatio: 10
       startingGear: SyndicateOperativeMedicFull
       unequipOldGear: true
       components:
@@ -119,7 +119,7 @@
       fallbackRoles: [ NukeopsCommander, NukeopsMedic ]
       spawnerPrototype: SpawnPointNukeopsOperative
       max: 10
-      playerRatio: 20
+      playerRatio: 10
       startingGear: SyndicateOperativeGearFull
       unequipOldGear: true
       components:
@@ -142,7 +142,7 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 30
+    minPlayers: 20
     cancelPresetOnTooFewPlayers: true # ShibaStation
   - type: RevolutionaryRule
   - type: AntagSelection
@@ -150,7 +150,7 @@
     definitions:
     - prefRoles: [ HeadRev ]
       max: 1
-      playerRatio: 20
+      playerRatio: 10
       briefing:
         text: head-rev-role-greeting
         color: CornflowerBlue
@@ -179,7 +179,7 @@
   components:
   - type: BlobRule
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 20
     cancelPresetOnTooFewPlayers: true # ShibaStation
   - type: AntagSelection
     selectionTime: BeforeJobs
@@ -205,12 +205,12 @@
     weight: 7 # ShibaStation - reduce the weight of blob spawns to ideally make them less frequent. In theory.
     duration: 1
     earliestStart: 160 # ShibaStation - Only after the first recall now
-    minimumPlayers: 30 # ShibaStation - up the min player requirement too, so less chance for nukies x blob simultaneously (but honestly that's just shitsec's problem)
+    minimumPlayers: 20 # ShibaStation - up the min player requirement too, so less chance for nukies x blob simultaneously (but honestly that's just shitsec's problem)
     maxOccurrences: 1
   - type: BlobSpawnRule
     carrierBlobProtos:
     - SpawnPointGhostBlobRat
-    playersPerCarrierBlob: 30
+    playersPerCarrierBlob: 20
     maxCarrierBlob: 1
 
 # - type: entity

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -31,7 +31,7 @@
   components:
   - type: HereticRule
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 7
   - type: AntagObjectives
     objectives:
     - HereticKnowledgeObjective
@@ -43,7 +43,7 @@
     definitions:
     - prefRoles: [ Heretic ]
       max: 3
-      playerRatio: 15
+      playerRatio: 5
       lateJoinAdditional: true
       mindRoles:
       - MindRoleHeretic

--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -6,7 +6,7 @@
     earliestStart: 35
     reoccurrenceDelay: 45
     weight: 1.5 # ShibaStation - make them way less common
-    minimumPlayers: 20 # ShibaStation - increased pop requirement. it's fun to have them around and they aren't a *threat* but they can seriously disrupt a low pop station in a negative way (unintentionally, it's just a symptom of low pop)
+    minimumPlayers: 12 # ShibaStation - increased pop requirement. it's fun to have them around and they aren't a *threat* but they can seriously disrupt a low pop station in a negative way (unintentionally, it's just a symptom of low pop)
     duration: 1
     maxOccurrences: 1 # can only happen once per round
   - type: RuleGrids
@@ -99,11 +99,12 @@
     earliestStart: 35 # ShibaStation - later start time
     reoccurrenceDelay: 45
     weight: 1.5 # ShibaStation - make them way less common
-    minimumPlayers: 25 # ShibaStation - increased pop requirement. it's fun to have them around and they aren't a *threat* but they can seriously disrupt a low pop station in a negative way (unintentionally, it's just a symptom of low pop)
+    minimumPlayers: 18 # ShibaStation - increased pop requirement. it's fun to have them around and they aren't a *threat* but they can seriously disrupt a low pop station in a negative way (unintentionally, it's just a symptom of low pop)
     duration: 1
-    chaos: # Goobstation
-      Hostile: 150
-      Medical: 150
+    maxOccurrences: 1 # can only happen once per round
+    # chaos: # Goobstation
+    #   Hostile: 150
+    #   Medical: 150
   - type: RuleGrids
   - type: LoadMapRule
     mapPath: /Maps/_Shitmed/Shuttles/ShuttleEvent/duo_abductor_shuttle.yml


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Lowered player count requirements and player ratios to get more antags to roll while working within our recognised average and peak player counts. Also a few adjustments to max reoccurrences and other small tweaks.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Now that we have playtime reqs for antags, I'm less concerned about antag tourism and antag rollers - and likewise we just don't get _as many_ antags as we _could_ due to higher requirements. We've been operating for several months now and seem to have found our average and peak player counts, so antag spawn and gamerule requirements have been adjusted to meet these numbers. There should be less 'sleepy shifts' where it's purely PvE going forward.

## Technical details
<!-- Summary of code changes for easier review. -->
number change in yaml lmao
