### PR TITLE
Improved Anomaly/Gas Leak Announcements; Expanded Admin Logs

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.Generator.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Generator.cs
@@ -184,14 +184,14 @@ public sealed partial class AnomalySystem
     // ShibaStation
     private void LogSpawnDetails(string prototype, EntityCoordinates coordinates)
     {
-        var anomalyLoc = _transform.ToMapCoordinates(coordinates).Position;
-        var x = (int)anomalyLoc.X;
-        var y = (int)anomalyLoc.Y;
+        var mapCords = _transform.ToMapCoordinates(coordinates);
+        var x = (int)mapCords.X;
+        var y = (int)mapCords.Y;
+        var mapId = mapCords.MapId;
 
+        _adminLogger.Add(LogType.EventRan, LogImpact.High, $"{prototype} spawned at ({x},{y}) on map {mapId}.");
         _chat.SendAdminAnnouncement($"{prototype} spawned at ({x},{y})");
-        _adminLogger.Add(LogType.EventRan, LogImpact.High, $"{prototype} spawned at ({x},{y})");
     }
-
 
     private void OnGeneratingStartup(EntityUid uid, GeneratingAnomalyGeneratorComponent component, ComponentStartup args)
     {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Shortened the admin announcements for Anomaly Spawn events and Gas leak events to include only immediately relevant details, while adding extra information to the actual admin logs. 


## Why / Balance

While the coordinates are usually sufficient to figure out where the gas leak or anomaly has spawned, we still need a map ID to fully support teleporting anywhere. I can't think of a situation where it would be absolutely necessary, but just in case, it's now included in the event logs.

Using the tp command, we can easily pull the coordinates from the admin announcement message and do `tp x y` to jump to the event location. And as mentioned, if it happens to be on a different map, the map ID is included in the admin logs as well. In that case, we can use `tp x y mapID`. That, and these coordinates match up with the coordinates on AstroNav, allowing us to ghostily float our way over to the drama center.

This should cover all our bases and make it exceptionally easy to keep track of these two threats to the crew.

## Technical details
Moved the logging in `GasLeakRule` into its own method. Changed grid coordinates to map coordinates for gas leak admin logs and announcements, and removed the grid ID from both. Added the map ID to event logging for anomaly spawns and gas leak events.

## Media
![image](https://github.com/user-attachments/assets/c0d9745f-c696-465f-b619-90b1e8b6b090)
![image](https://github.com/user-attachments/assets/54dd8094-9573-4afe-abb9-757995cc71f1)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


:cl:
- tweak: Anomaly and gas leak event announcements now show cleaner info, with full details available in admin logs.

