### PR TITLE
Lavaland Bluespace Shelter Fix 

### DIFF
--- a/Content.Server/_Lavaland/Salvage/ShelterCapsuleSystem.cs
+++ b/Content.Server/_Lavaland/Salvage/ShelterCapsuleSystem.cs
@@ -61,8 +61,12 @@ public sealed class ShelterCapsuleSystem : SharedShelterCapsuleSystem
         var spreadAmount = (int) Math.Round(comp.BoxSize.Length() * 2);
         _smoke.StartSmoke(foamEnt, new Solution(), comp.DeployTime + 2f, spreadAmount);
 
-        if (!_preloader.TryGetPreloadedGrid(comp.PreloadedGrid, out var shelter))
-        {
+        // ShibaStation — Preloading currently causes shelter grids to skip normal map initialization.
+        // This breaks things like ContainerFillComponent, which installs door electronics for functioning doors.
+        // As a result, we always run the fallback system for now.
+
+        //if (!_preloader.TryGetPreloadedGrid(comp.PreloadedGrid, out var shelter))
+        //{
             _mapSystem.CreateMap(out var dummyMap);
             if (!_mapLoader.TryLoadGrid(dummyMap, path, out var shelterEnt))
             {
@@ -73,10 +77,11 @@ public sealed class ShelterCapsuleSystem : SharedShelterCapsuleSystem
             SetupShelter(shelterEnt.Value.Owner, new EntityCoordinates(mapEnt, posFixed.Position));
             _mapSystem.DeleteMap(dummyMap);
             return true;
-        }
+        //}
 
-        SetupShelter(shelter.Value, new EntityCoordinates(mapEnt, posFixed.Position));
-        return true;
+        // If preloader works in the future, we can re-enable this:
+        // SetupShelter(shelter.Value, new EntityCoordinates(mapEnt, posFixed.Position));
+        // // return true;
     }
 
     private void SetupShelter(Entity<TransformComponent?> shelter, EntityCoordinates coords)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

fixes #175

## About the PR
Disabled the use of preloaded shelter grids in `ShelterCapsuleSystem.cs` due to a seemingly flawed implementation specific to this system. The fallback method is now always used.

## Why / Balance
While preloading grids seems to work in other contexts, check the `LoadMapRule` for their implementation. Within `ShelterCapsuleSystem` it is currently not working as intended. Grids spawned from capsules seem to skip normal map initialization, which leads to issues like missing `ContainerFillComponent` not able to fill door containers with `DoorElectronics`. 

These issues are not related to the Shelters themselves. if you replace the shelter grids usually spawned to, say, a shuttle, those shuttle doors will also have the same door issues. 

This fallback solution may be slightly less performant since we’re no longer relying on the preloaded grids. (They are still preloaded in this solution, just not used due to the issues.) However, the performance impact should be negligible. This is intended as a temporary band-aid fix anyways.

**Changelog**
:cl:
- fix: Shelters created via the shelter capsule now have functioning doors