### PR TITLE
Made Universal Access Configurators spawn with a Universal ID card.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -136,3 +136,7 @@
     denialSound:
       path: /Audio/Machines/custom_deny.ogg
     doAfter: 0.5
+  - type: ContainerFill # ShibaStation
+    containers:
+      AccessOverrider-privilegedId:
+      - UniversalIDCard


### PR DESCRIPTION
## About the PR
Refer to title! 

## Why / Balance
During local testing, constantly removing and reinserting an ID into the Universal Access Configurator became EXTRA tedious. Since this is an admin only item, there's no real balance concern with streamlining its use. In nearly every case where it's needed, it's far more convenient to have it pre-loaded with a Universal ID card.

> Because I'm feline lazy.

## Technical details
Added a `ContainerFill` component to Universal Access Configurator, which places a `UniversalIDCard` into the `AccessOverrider-privilegedId` container on creation.

:cl:
ADMIN:
- add:  Universal Access Configurators now spawn with a Universal ID card inserted.
