### PR TITLE
Disabled carrying on all species

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -297,7 +297,7 @@
         Asphyxiation: -1.0
   - type: FireVisuals
     alternateState: Standing
-  - type: Carriable # Goobstation
+  # - type: Carriable # ShibaStation - Disabled carrying; it's buggy. It may get fixed in the future but it's not a priority.
   - type: CPRTraining # Goobstation - Just give to everyone! This ain't MRP.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -7,7 +7,7 @@
   id: BaseMobSkeletonPerson
   abstract: true
   components:
-  - type: Carriable # Goobstation
+  # - type: Carriable # ShibaStation - Disabled carrying; it's buggy. It may get fixed in the future but it's not a priority.
   - type: HumanoidAppearance
     species: Skeleton
   - type: Icon

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -9,7 +9,7 @@
     species: Rodentia
   - type: Hunger
     baseDecayRate: 0.0467 # 33% faster than usual
-  - type: Carriable # Carrying system from nyanotrasen.
+  # - type: Carriable # ShibaStation - Disabled carrying; it's buggy. It may get fixed in the future but it's not a priority.
   - type: Inventory
     speciesId: rodentia
   - type: Icon

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -318,6 +318,6 @@
       lightningExplode: false
     - type: ComplexInteraction
     - type: FootPrints
-    - type: Carriable
+    # - type: Carriable # ShibaStation - Disabled carrying; it's buggy. It may get fixed in the future but it's not a priority.
     - type: Targeting
     - type: LayingDown

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
@@ -39,8 +39,8 @@
   - type: Metabolizer
     updateInterval: 3
   - type: BoganAccent
-  - type: Carriable
-    freeHandsRequired: 4 # easiest way to make them uncarriable without removing carriable from base mob
+  # - type: Carriable # ShibaStation - Disabled carrying; it's buggy. It may get fixed in the future but it's not a priority.
+  #   freeHandsRequired: 4 # easiest way to make them uncarriable without removing carriable from base mob
   - type: NoWieldNeeded
   - type: OuterSlotPenalty
     equippedSpeedMultiplier: 0.8


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Commented out the carrying component from all species.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Kind of but not really fixes #177 - a real fix would be to address the problems that carrying has now, but ultimately I don't see much need to keep carrying in its current form. It's less effective than just pulling a downed body out of danger, the grabbing system has throwing now which is something carrying permitted exclusively, and the bugs that can occur due to certain situations are literally game breaking. It's only purpose it had was either for RP or for shitters to be annoying with - and unfortunately I don't see much value in it.

The system itself hasn't been _removed_ from the codebase, and it may be looked at later to be fixed up and re-enabled for all species, but for now it's a low priority.

## Technical details
<!-- Summary of code changes for easier review. -->
Commented out lines in yaml files, no code changes.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Removed fun!
