### PR TITLE
Rodentians Can Vent Crawl

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -117,6 +117,8 @@
     actionProto: ActionToggleSneakMode
   - type: FootPrints # WD EDIT
   - type: RodentiaAccent # ShibaStation - give da maus a funny accent
+  - type: VentCrawler # ShibaStation - let ratmen vent crawl but they can't take an inventory
+    allowInventory: false
 
 - type: entity
   save: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Gave Rodentians the ability to vent crawl natively; but they can't take a backpack, outerwear or anything in the suit storage slot.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is a pre-emptive species buff since a change is going to be made to sneaking/crawling under tables soon; so this gives Rodentians something special. It feels pretty on-point for the ratmen to be able to scurry in vents, but it comes with many penalties that makes it a higher risk maneuver.

Firstly, you can't take a backpack, outerwear/suit or anything on suit storage. You can only take what fits in your pockets (and mouth).

Secondly, vent crawling is LOUD so people will hear you doing it, if you're trying to sneak around.

Thirdly, you take pressure and airloss damage the longer you stay in there. You will be popping out the other end with some level of damage.

This helps balance its utility as an infiltration/tider ability, but also does open up extra avenues for rodentian players to experiment with approaches to thievery and other means to get access to areas.

## Technical details
<!-- Summary of code changes for easier review. -->
Just added the `VentCrawler` component to Rodentians and set `allowInventory` to false!
