### PR TITLE
All Species can Crawl/Sneak Under Tables while Prone

### DIFF
--- a/Content.Client/_DV/Abilities/CrawlUnderObjectsSystem.cs
+++ b/Content.Client/_DV/Abilities/CrawlUnderObjectsSystem.cs
@@ -6,6 +6,8 @@ namespace Content.Client._DV.Abilities;
 
 public sealed partial class HideUnderTableAbilitySystem : SharedCrawlUnderObjectsSystem
 {
+    // ShibaStation - The client-side rendering is only concerned with the enabled state of sneaking,
+    // ShibaStation - which will be controlled server-side based on the SneakWhileStanding parameter
     [Dependency] private readonly AppearanceSystem _appearance = default!;
 
     public override void Initialize()

--- a/Content.Shared/_DV/Abilities/CrawlUnderObjectsComponent.cs
+++ b/Content.Shared/_DV/Abilities/CrawlUnderObjectsComponent.cs
@@ -29,6 +29,13 @@ public sealed partial class CrawlUnderObjectsComponent : Component
 
     [DataField]
     public float SneakSpeedModifier = 0.7f;
+
+    /// <summary>
+    ///     Whether the entity can sneak while standing.
+    ///     ShibaStation - If false, entity must be in laying state to sneak.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool SneakWhileStanding = false;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_DV/Abilities/SharedCrawlUnderObjectsSystem.cs
+++ b/Content.Shared/_DV/Abilities/SharedCrawlUnderObjectsSystem.cs
@@ -1,4 +1,3 @@
-
 using Content.Shared.Popups;
 
 namespace Content.Shared._DV.Abilities;
@@ -11,6 +10,8 @@ public abstract class SharedCrawlUnderObjectsSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<CrawlUnderObjectsComponent, CrawlingUpdatedEvent>(OnCrawlingUpdated);
+
+        // ShibaStation - Note: The server-side implementation subscribes to StoodEvent to disable sneaking when appropriate
     }
 
     private void OnCrawlingUpdated(EntityUid uid,

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -299,6 +299,8 @@
     alternateState: Standing
   - type: Carriable # Goobstation
   - type: CPRTraining # Goobstation - Just give to everyone! This ain't MRP.
+  - type: CrawlUnderObjects # ShibaStation - Let species sneak but only while laying down.
+    actionProto: ActionToggleSneakMode
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -107,6 +107,8 @@
     alternateState: Standing
   - type: FlashImmunity
   - type: FootPrints # WD EDIT
+  - type: CrawlUnderObjects # ShibaStation - Let species sneak but only while laying down.
+    actionProto: ActionToggleSneakMode
   - type: Tag # Goobstation
     tags:
     - CanPilot

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -115,6 +115,8 @@
     spitDamageThreshold: 3
   - type: CrawlUnderObjects
     actionProto: ActionToggleSneakMode
+    sneakWhileStanding: true
+    sneakSpeedModifier: 0.85
   - type: FootPrints # WD EDIT
   - type: RodentiaAccent # ShibaStation - give da maus a funny accent
 

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -164,6 +164,8 @@
   - type: Speech # ShibaStation - Better IPC noises; pAI too small, borg makes more sense.
     speechVerb: Robotic
     speechSounds: Borg
+  - type: CrawlUnderObjects # ShibaStation - Let species sneak but only while laying down.
+    actionProto: ActionToggleSneakMode
 
 - type: entity
   save: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Permit all species to be able to crawl/sneak under tables/furniture while crawling/prone/downed/whatever like Rodentians. Rodentians, however, can still sneak while standing, and move a little bit faster than previously while sneaking.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Changes to laying preventing moving over tables and giving Rodentians the ability to vent crawl natively permit sneaking/crawling under to be something that all species can benefit from now, with the caveat that they must be lying down.

A new parameter has been added to the CrawlUnderObjects system which permits sneaking while standing, which was the previous default behaviour but is now unique to Rodentians. By default it's false, meaning that other species must be laying down to toggle the ability. The action will appear while laying down, and disappear when standing, to prevent UI clutter.

Should open up some interesting new avenues of gameplay, including sneaky hide and seek instances. 

## Technical details
<!-- Summary of code changes for easier review. -->
Uuuuh lots of stuff, see diffs - primarily added event checks when laying/standing to drive access to the sneaking ability and ensuring sneaking is no longer active when standing. Added the new parameter to the CrawlUnderObjects component to permit sneaking without laying down (classic Rodentian behaviour) and added the component to all playable species (I hope, inheritance sucks).
