### PR TITLE
Ariral tweaks & fixes

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -28,6 +28,8 @@
     - Oni
     - Resomi
     - Tajaran
+    # ShibaStation - Custom Races
+    - Ariral
 
 - type: loadoutEffectGroup
   id: EffectSpeciesVox

--- a/Resources/Prototypes/_ShibaStation/Entities/Mobs/Species/ariral.yml
+++ b/Resources/Prototypes/_ShibaStation/Entities/Mobs/Species/ariral.yml
@@ -21,6 +21,7 @@
   - type: InteractionPopup
     successChance: 0
     interactFailureString: petting-failure-ariral
+    messagePerceivedByOthers: null
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/_ShibaStation/Entities/Mobs/Species/ariral.yml
+++ b/Resources/Prototypes/_ShibaStation/Entities/Mobs/Species/ariral.yml
@@ -32,8 +32,8 @@
     critThreshold: 75 # Less stamina, easier to down.
   - type: Bloodstream # Ariral blood is unique and toxic, but arirals bleed very easily and don't passively heal as fast.
     bloodReagent: AriralBlood
-    bloodRefreshAmount: 0.5
-    bleedReductionAmount: 0.1
+    bloodRefreshAmount: 0.85
+    bleedReductionAmount: 0.25
     damageBleedModifiers: BloodlossAriral
   - type: MeleeWeapon
     soundHit:
@@ -46,17 +46,17 @@
         Blunt: 3 # Less melee damage but they apply poison after two+ hits.
   - type: SolutionContainerManager # Contact with arirals is toxic, so we need a way to transfer that in melee combat.
     solutions:
-      melee:
+      skin:
         maxVol: 30
   - type: SolutionRegeneration
-    solution: melee
+    solution: skin
     generated:
       reagents:
       - ReagentId: AriralSweat
-        Quantity: 5
+        Quantity: 0.5
   - type: MeleeChemicalInjector # Effects should be applied after two hits, three+ applying poison.
-    solution: melee
-    transferAmount: 5
+    solution: skin
+    transferAmount: 1
   - type: HumanoidAppearance
     species: Ariral
     hideLayersOnEquip:

--- a/Resources/Prototypes/_ShibaStation/Reagents/biological.yml
+++ b/Resources/Prototypes/_ShibaStation/Reagents/biological.yml
@@ -5,12 +5,9 @@
   desc: reagent-desc-ariral-blood
   flavor: metallic
   color: "#d82000"
-  metamorphicSprite:
-    sprite: Objects/Consumable/Drinks/bloodglass.rsi
-    state: icon_empty
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
-  metamorphicChangeColor: false
+  metamorphicChangeColor: true
   recognizable: true
   physicalDesc: reagent-physical-desc-ferrous
   slippery: false
@@ -23,41 +20,41 @@
           type: Ariral
           shouldHave: false
         - !type:ReagentThreshold
-          min: 2
-        probability: 0.3
+          min: 1
+        probability: 0.5
       - !type:GenericStatusEffect
         conditions:
         - !type:OrganType
           type: Ariral
           shouldHave: false
         - !type:ReagentThreshold
-          min: 3
+          min: 1
         key: SeeingRainbows
         component: SeeingRainbows
         type: Add
         time: 8
-        refresh: false
+        refresh: true
       - !type:PopupMessage
         conditions:
         - !type:OrganType
           type: Ariral
           shouldHave: false
         - !type:ReagentThreshold
-          min: 3
+          min: 1
         type: Local
         visualType: Medium
         messages: ["generic-reagent-effect-nauseous", "generic-reagent-effect-dizzy"]
-        probability: 0.3
+        probability: 0.4
       - !type:HealthChange
         conditions:
         - !type:OrganType
           type: Ariral
           shouldHave: false
         - !type:ReagentThreshold
-          min: 4
+          min: 2
         damage:
           types:
-            Poison: 0.75
+            Poison: 1.25
   footstepSound:
     collection: FootstepBlood
     params:
@@ -70,13 +67,10 @@
   desc: reagent-desc-ariral-sweat
   flavor: metallic
   color: "#e0e0e0"
-  metamorphicSprite:
-    sprite: Objects/Consumable/Drinks/bloodglass.rsi
-    state: icon_empty
   metamorphicMaxFillLevels: 5
   metamorphicFillBaseName: fill-
-  metamorphicChangeColor: false
-  recognizable: true
+  metamorphicChangeColor: true
+  recognizable: false
   physicalDesc: reagent-physical-desc-volatile
   slippery: true
   metabolisms:
@@ -88,27 +82,27 @@
           type: Ariral
           shouldHave: false
         - !type:ReagentThreshold
-          min: 8
-        probability: 0.2
+          min: 1
+        probability: 0.4
       - !type:GenericStatusEffect
         conditions:
         - !type:OrganType
           type: Ariral
           shouldHave: false
         - !type:ReagentThreshold
-          min: 12
+          min: 1
         key: SeeingRainbows
         component: SeeingRainbows
         type: Add
         time: 6
-        refresh: false
+        refresh: true
       - !type:PopupMessage
         conditions:
         - !type:OrganType
           type: Ariral
           shouldHave: false
         - !type:ReagentThreshold
-          min: 12
+          min: 1
         type: Local
         visualType: Medium
         messages: ["generic-reagent-effect-nauseous", "generic-reagent-effect-dizzy"]
@@ -119,7 +113,7 @@
           type: Ariral
           shouldHave: false
         - !type:ReagentThreshold
-          min: 16
+          min: 2
         damage:
           types:
-            Poison: 0.5
+            Poison: 0.75


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes #193 #195 and possibly #196
Adjusts ariral reagents to be more potent, but makes the melee injector administer less per hit.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Arirals need survival boxes!
They bled a bit TOO much too easily; arith treatment was basically a death sentence without gauze. While I like this as a medical challenge, it was still a bit TOO excessive. Their clotting rate has been upped as well as their blood regen amounts however it's still lower than average, so they'll most likely still need gauze or other bleed-stopper options. Finally a use for inap?
Hopefully stops the interact message popping up on the target now too; since the funny meme is that they can't get hugged.

## Technical details
<!-- Summary of code changes for easier review. -->
yaml adjustments, no code
