### PR TITLE
Midround Antag Rebalancing

### DIFF
--- a/Content.Goobstation.Shared/Changeling/Components/ChangelingIdentityComponent.cs
+++ b/Content.Goobstation.Shared/Changeling/Components/ChangelingIdentityComponent.cs
@@ -74,7 +74,7 @@ public sealed partial class ChangelingIdentityComponent : Component
     ///     How much biomass should be removed per cycle.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float BiomassDrain = 1f;
+    public float BiomassDrain = 0.75f; // ShibaStation - our rounds are longer by default, so lings get a bit more time before needing to absorb.
 
     /// <summary>
     ///     Current amount of chemicals changeling currently has.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -45,7 +45,7 @@
     - id: LoneOpsSpawn
     - id: DerelictCyborgSpawn
     - id: BlobSpawn # Goobstation - Blob
-    - id: LoneAbductorSpawn # Shitmed - Starlight Abductors
+    # - id: LoneAbductorSpawn # Shitmed - Starlight Abductors # ShibaStation - aliems come in pairs only now
     - id: DuoAbductorSpawn # Shitmed - Starlight Abductors
     # - id: BingleSpawn #Goobstation - Bingle # ShibaStation - Pretty sure this is memeshit, so I'm disabling it for now.
 
@@ -527,7 +527,7 @@
   id: SleeperAgents
   components:
   - type: StationEvent
-    earliestStart: 30
+    earliestStart: 20
     weight: 8
     minimumPlayers: 12
     maxOccurrences: 1 # can only happen once per round

--- a/Resources/Prototypes/_Goobstation/Changeling/Objectives/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Objectives/changeling.yml
@@ -42,8 +42,8 @@
       sprite: Mobs/Species/Human/organs.rsi
       state: brain
   - type: NumberObjective
-    min: 6
-    max: 9
+    min: 2
+    max: 6
     title: objective-condition-stealdna-title
     description: objective-condition-stealdna-description
   - type: StealDNACondition

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -38,9 +38,10 @@
   id: ChangelingMidround
   components:
   - type: StationEvent
-    earliestStart: 30
-    weight: 3
-    minimumPlayers: 7
+    earliestStart: 10
+    weight: 2
+    minimumPlayers: 12
+    maxOccurrences: 1
     startAnnouncement: station-event-communication-interception
     startAudio:
       path: /Audio/_ShibaStation/Announcements/sleeper-activate.ogg
@@ -73,9 +74,10 @@
   id: HereticMidround
   components:
   - type: StationEvent
-    earliestStart: 30
-    weight: 3
-    minimumPlayers: 7
+    earliestStart: 15
+    weight: 4
+    minimumPlayers: 10
+    maxOccurrences: 1
     startAnnouncement: station-event-communication-interception
     startAudio:
       path: /Audio/_ShibaStation/Announcements/sleeper-activate.ogg

--- a/Resources/Prototypes/_Goobstation/Heretic/Objectives/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Objectives/heretic.yml
@@ -16,8 +16,8 @@
       sprite: _Goobstation/Heretic/reality_fracture.rsi
       state: icon_harvested
   - type: NumberObjective
-    min: 12
-    max: 18
+    min: 8
+    max: 14
     title: objective-condition-knowledge-title
   - type: HereticKnowledgeCondition
 
@@ -30,8 +30,8 @@
       sprite: _Goobstation/Heretic/Blades/blade_blade.rsi
       state: icon
   - type: NumberObjective
-    min: 2
-    max: 4
+    min: 1
+    max: 3
     title: objective-condition-sacrifice-title
   - type: HereticSacrificeCondition
 

--- a/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
@@ -55,8 +55,8 @@
   components:
   - type: StationEvent
     earliestStart: 35
-    weight: 5.5
-    minimumPlayers: 15
+    weight: 2
+    minimumPlayers: 14
     duration: 1
     chaos: # Goobstation
       Hostile: 200

--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -99,7 +99,7 @@
     earliestStart: 35 # ShibaStation - later start time
     reoccurrenceDelay: 45
     weight: 1.5 # ShibaStation - make them way less common
-    minimumPlayers: 18 # ShibaStation - increased pop requirement. it's fun to have them around and they aren't a *threat* but they can seriously disrupt a low pop station in a negative way (unintentionally, it's just a symptom of low pop)
+    minimumPlayers: 16 # ShibaStation - increased pop requirement. it's fun to have them around and they aren't a *threat* but they can seriously disrupt a low pop station in a negative way (unintentionally, it's just a symptom of low pop)
     duration: 1
     maxOccurrences: 1 # can only happen once per round
     # chaos: # Goobstation


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adjusted the requirements and frequency of the midround antag events.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We need to pump the brakes a little on the chaos _just enough_ to keep room for MRP. Every round now has the chance to have at least four antagonists at a modest (by our standards) population. Heretics, Changelings and the Wizard have now been capped to one instance per round - Wizard army should be kept to an admeme :kek:

Changeling biomass drain has been reduced by 25% to let them go longer before they _need_ to absorb DNA to survive, since our rounds go a bit longer. A modest changeling that doesn't want to murderbone can probably go on about two feeds a standard shift round, with the need to do another per extension - which seems pretty fair, the crew shouldn't be letting The Thing wander around unopposed!

## Technical details
<!-- Summary of code changes for easier review. -->
Mostly yaml changes, one small change in a .cs file.
