### PR TITLE
Reduce tendon health down from 40 to 12

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -196,7 +196,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 40
+          damage: 12 # ShibaStation - make tendons less robust
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Reduce tendon health down from 40 to 12
Fixes #225

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
While I appreciate that the result of a meat anom should be a challenge, they felt FAR too difficult to manage even with multiple crew; turns out they have 4x the health of regular kudzu on top of the fact that they HEAL when they grow (unlike kudzu). Rather than totally nerf the challenge, they've had their health dropped from 40 to 12, which is still a smidge more than regular plant kudzu but should still be one-shotable with a decent weapon. Before, due to the massive health pool, rapid growth and healing on growth, it was practically impossible to deal with without first spacing the room and going in hazmat style. While that conceptually sounds "fun", in practice it was more annoying than its worth.

## Technical details
<!-- Summary of code changes for easier review. -->
yamlmaxxing

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Meat Kudzu (Tendons) have had their health reduced: 40 -> 12.
