### PR TITLE
Give Command access to Cappy's Room under Extended Access conditions

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -31,6 +31,8 @@
   - Brig
   - Cryogenics
   - External # goobstation
+  extendedAccess:
+  - Captain # ShibaStation - Let Command have access to Captain's Room during Low Pop
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -49,6 +49,8 @@
   - Cargo
   - Atmospherics
   - Medical
+  extendedAccess:
+  - Captain # ShibaStation - Let Command have access to Captain's Room during Low Pop
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -30,6 +30,8 @@
   - Atmospherics
   - Brig
   - Cryogenics
+  extendedAccess:
+  - Captain # ShibaStation - Let Command have access to Captain's Room during Low Pop
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -32,6 +32,7 @@
   - External # goobstation
   extendedAccess:
   - Research # ShibaStation - Added Research to CMO access
+  - Captain # ShibaStation - Let Command have access to Captain's Room during Low Pop
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -26,6 +26,7 @@
   extendedAccess:
   - Medical # ShibaStation - Added Medical to RD access
   - Chemistry # ShibaStation - Added Chemistry to RD access
+  - Captain # ShibaStation - Let Command have access to Captain's Room during Low Pop
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -35,6 +35,7 @@
   extendedAccess:
   - Medical # ShibaStation - Added Medical to HoS access
   - Chemistry # ShibaStation - Added Chemistry to HoS access
+  - Captain # ShibaStation - Let Command have access to Captain's Room during Low Pop
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -24,6 +24,7 @@
   extendedAccess:
   - Medical # ShibaStation - Added Medical to Warden access
   - Chemistry # ShibaStation - Added Chemistry to Warden access
+  - Captain # ShibaStation - Let Command have access to Captain's Room during Low Pop
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added `Captain` to the Command (+ Warden) `extendedAccess` job component parameters.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
People are allergic to playing Captain but want to tide in to get his gear when they have to be Acting Captain instead; at least this way they can just walk in and give themselves AA instead of having to break in like common criminals.

Command are still expected to follow SOP correctly; meaning that only the present Command member who sits at the top of the Chain of Command should be rummaging through Captain's sock drawer.

## Technical details
<!-- Summary of code changes for easier review. -->
yamlmao

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Command (and Warden) get access to the Captain's Room during 'Extended Access' population counts. Command should still be following SOP and the CoC correctly, but now you can stop breaking into the Captain's room every shift.

