### PR TITLE
No Dead Chat from Summon Ghosts Spell

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -970,14 +970,12 @@ public sealed partial class ChatSystem : SharedChatSystem
 
     private IEnumerable<INetChannel> GetDeadChatClients()
     {
-        if (_ghostVisibility.GhostsVisible()) // Goobstation
+        if (_ghostVisibility.CanSeeDeadChat()) // Goobstation
             return Filter.Broadcast().Recipients.Select(p => p.Channel);
 
         return Filter.Empty()
-            .AddWhereAttachedEntity(HasComp<GhostComponent>)
-            .AddWhereAttachedEntity(_scrying.IsScryingOrbEquipped) // Goobstation
+            .AddWhereAttachedEntity(p => HasComp<GhostComponent>(p) || _adminManager.IsAdmin(p))
             .Recipients
-            .Union(_adminManager.ActiveAdmins)
             .Select(p => p.Channel);
     }
 

--- a/Content.Server/_Shitcode/Wizard/Systems/GhostVisibilitySystem.cs
+++ b/Content.Server/_Shitcode/Wizard/Systems/GhostVisibilitySystem.cs
@@ -71,4 +71,9 @@ public sealed class GhostVisibilitySystem : SharedGhostVisibilitySystem
 
         return !component.CanGhostInteract;
     }
+
+    public bool CanSeeDeadChat()
+    {
+        return false; // Dead chat is only visible to ghosts and admins
+    }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The `Summon Ghosts` spell no longer allows living, non-admin players from hearing Dead Chat.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
There's been some confusion over the validity of seeing Dead Chat as a living player mid-round, as Dead Chat is considered Out of Character. Rather than impose a dynamic rule on ghost players that they must become IC if the spell is used, as per vote on Discord we instead simply hide Dead Chat from players who are **not**:
* Ghosts
* Admins

The spell still makes the ghost sprites visible and from an admin's perspective we're still okay with players gleaning information as a result of this, as per the Wizard 'causing chaos' - although this may be subject to change (and isn't in the scope of this PR anyway).

## Technical details
<!-- Summary of code changes for easier review. -->
Added a `bool` to the `GhostVisibilitySystem` that always returns false and instead filters out dead chat for only admins or ghosts. This means ghosts are still visible when the spell is used but dead chat is still restricted to ghosts and admins only.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The Summon Ghosts spell no longer allows the living to commune with the dead - but they can still see them!

