### PR TITLE
Fixed broken discord invite link (once again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Documentation is coming soon™
 
 ## Contributing
 
-We are happy to accept contributions from anybody. Get in [Discord](https://discord.gg/yMQkrSdeWn) if you want to help. Feel free to check the [list of issues](https://github.com/AstroDogeDX/ShibaStation-GS/issues) that need to be done and anybody can pick them up. Don't be afraid to ask for help either!
+We are happy to accept contributions from anybody. Get in [Discord](https://discord.gg/shibastation) if you want to help. Feel free to check the [list of issues](https://github.com/AstroDogeDX/ShibaStation-GS/issues) that need to be done and anybody can pick them up. Don't be afraid to ask for help either!
 While ShibaStation doesn't use the [contribution guidelines,](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) you can feel free to if you want to check your stuff.
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Documentation is coming soon™
 
 ## Contributing
 
-We are happy to accept contributions from anybody. Get in [Discord](https://discord.gg/ZbMBR2c5VR) if you want to help. Feel free to check the [list of issues](https://github.com/AstroDogeDX/ShibaStation-GS/issues) that need to be done and anybody can pick them up. Don't be afraid to ask for help either!
+We are happy to accept contributions from anybody. Get in [Discord](https://discord.gg/yMQkrSdeWn) if you want to help. Feel free to check the [list of issues](https://github.com/AstroDogeDX/ShibaStation-GS/issues) that need to be done and anybody can pick them up. Don't be afraid to ask for help either!
 While ShibaStation doesn't use the [contribution guidelines,](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) you can feel free to if you want to check your stuff.
 
 ## Building


### PR DESCRIPTION
Second link in "Readme" was expired, copied first one (after confirming it works)
This time with "vanity" discord link

## About the PR
Fixed broken discord invite link, copied first one (after confirming it works)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->